### PR TITLE
Remove animations for prefers-reduced-motion

### DIFF
--- a/packages/site/assets/css/style.css
+++ b/packages/site/assets/css/style.css
@@ -1265,6 +1265,7 @@ label input[type="radio"] {
 .banner-shape-inner .shape5 {
   top: 43%;
   left: 49%;
+  z-index: -1;
 }
 
 .banner-shape-inner .shape6 {
@@ -3426,5 +3427,14 @@ h1 span {
   .side-menu__social a {
     width: 45px;
     height: 45px;
+  }
+}
+
+@media (prefers-reduced-motion) {
+  .rotate-2d,
+  .rotate2d,
+  .rotate3d,
+  .banner-image {
+    animation: none;
   }
 }


### PR DESCRIPTION
This PR fixes some accessibility issues. First, move the shape that was on top of the introduction text back in `z-index` to make the text more legible.

Second, remove the animation of the shapes and the iPhone if the user has set [`prefers-reduced-motion`](https://css-tricks.com/introduction-reduced-motion-media-query/).