### PR TITLE
Fix typos and Swedish currency

### DIFF
--- a/packages/site/components/Banner.js
+++ b/packages/site/components/Banner.js
@@ -62,7 +62,7 @@ const Banner = () => {
                 <h1>Öppna Skolplattformen</h1>
                 <p>
                   Oavsett om du har tre eller sju barn - det är mycket att hålla
-                  reda på. Stövlarna. Frånvaruanmälan nummer 17 i februari. Vad
+                  reda på. Stövlarna. Frånvaroanmälan nummer 17 i februari. Vad
                   vikarien heter den här veckan. En dåligt fungerande
                   Skolplattform som äter tid och ork? Det finns inte plats för
                   det. Så vi har byggt en bättre. Med all information du behöver

--- a/packages/site/components/CtaTwo.js
+++ b/packages/site/components/CtaTwo.js
@@ -17,7 +17,7 @@ const CtaTwo = () => {
               <h2>Lika säkert</h2>
               <p>
                 Ingen information om dina barn skickas till oss, all
-                kommunikatoin går direkt mellan din telefon och Skolplattformens
+                kommunikation går direkt mellan din telefon och Skolplattformens
                 servrar. Du loggar in med BankID som vanligt.
               </p>
               <a href="#" className="btn">

--- a/packages/site/components/Pricing.js
+++ b/packages/site/components/Pricing.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { formatPrice } from '../utils/intl'
 
 const Pricing = () => {
   const [pricing] = useState(false)
@@ -13,8 +14,8 @@ const Pricing = () => {
               <p>
                 Vi som bygger appen vill gärna fortsätta vidareutveckla den och
                 även ha möjlighet att ge ersättning till de som hjälper till.
-                Därför kostar det 10kr att ladda ner appen. Det är en
-                engångskostnad och hjälper oss att göra appen bättre.
+                Därför kostar det {formatPrice(10)} att ladda ner appen. Det är
+                en engångskostnad och hjälper oss att göra appen bättre.
               </p>
             </div>
           </div>
@@ -29,7 +30,7 @@ const Pricing = () => {
                       <div className="single-price-plan text-center">
                         <div className="single-price-top">
                           <h4>Engångskostnad</h4>
-                          <span>10kr</span>
+                          <span>{formatPrice(10)}</span>
                         </div>
                         <div className="single-price-body">
                           <div className="price-list">
@@ -41,7 +42,7 @@ const Pricing = () => {
                                     aria-hidden="true"
                                   ></i>
                                 </span>
-                                BankID inloggning
+                                BankID-inloggning
                               </li>
                               <li>
                                 <span>

--- a/packages/site/components/Testimonials.js
+++ b/packages/site/components/Testimonials.js
@@ -116,7 +116,7 @@ const Testimonials = () => {
                     fungerar. Öppna Skolplattformen är ett bra exempel på
                     detta!&rdquo;
                   </h4>
-                  <p>Niels PaarupPetersen, Riksdagsledamot C</p>
+                  <p>Niels Paarup-Petersen, Riksdagsledamot C</p>
                 </SwiperSlide>
               </Swiper>
               <div className="testimonial-author-comment-nav">

--- a/packages/site/utils/intl.js
+++ b/packages/site/utils/intl.js
@@ -1,0 +1,9 @@
+export const formatNumber = (input, options = {}) =>
+  new Intl.NumberFormat('sv-SE', options).format(input)
+
+export const formatPrice = (input) =>
+  formatNumber(input, {
+    currency: 'SEK',
+    minimumFractionDigits: 0,
+    style: 'currency',
+  })


### PR DESCRIPTION
In this PR I fix two typos and handling of Swedish currency.

According to "Svenska skrivregler" there should be a `&nbsp;` between the value and the currency `kr`. By using the [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) API we get the formatting for free.