### PR TITLE
fix: handle line breaks in tab navigation

### DIFF
--- a/packages/app/components/child.component.js
+++ b/packages/app/components/child.component.js
@@ -57,6 +57,12 @@ export const Child = ({route, navigation}) => {
     <TopNavigationAction icon={BackIcon} onPress={navigateBack} />
   )
 
+  const TabTitle = ({style, children}) => (
+    <Text adjustsFontSizeToFit numberOfLines={1} style={style}>
+      {children}
+    </Text>
+  )
+
   const navigateBack = () => {
     navigation.goBack()
   }
@@ -102,12 +108,16 @@ export const Child = ({route, navigation}) => {
       <TabView
         selectedIndex={selectedIndex}
         onSelect={(index) => setSelectedIndex(index)}>
-        <Tab title="Nyheter" icon={NewsIcon}>
+        <Tab
+          title={(props) => <TabTitle {...props}>Nyheter</TabTitle>}
+          icon={NewsIcon}>
           <Layout style={styles.tabContainer}>
             <NewsList news={news} />
           </Layout>
         </Tab>
-        <Tab title="Notifieringar" icon={NotificationsIcon}>
+        <Tab
+          title={(props) => <TabTitle {...props}>Notifieringar</TabTitle>}
+          icon={NotificationsIcon}>
           <Layout style={styles.tabContainer}>
             <NotificationsList
               notifications={notifications}
@@ -115,12 +125,16 @@ export const Child = ({route, navigation}) => {
             />
           </Layout>
         </Tab>
-        <Tab title="Kalender" icon={CalendarIcon}>
+        <Tab
+          title={(props) => <TabTitle {...props}>Kalender</TabTitle>}
+          icon={CalendarIcon}>
           <Layout style={styles.tabContainer}>
             <Calendar calendar={[...(calendar ?? []), ...(schedule ?? [])]} />
           </Layout>
         </Tab>
-        <Tab title="Klassen" icon={ClassIcon}>
+        <Tab
+          title={(props) => <TabTitle {...props}>Klassen</TabTitle>}
+          icon={ClassIcon}>
           <Layout style={styles.tabContainer}>
             <Text category="h5">
               Klass {classmates?.length ? classmates[0].className : ''}

--- a/packages/app/components/newsListItem.component.js
+++ b/packages/app/components/newsListItem.component.js
@@ -16,7 +16,7 @@ export const NewsListItem = ({item}) => {
       header={(headerProps) => (
         <View {...headerProps}>
           <Text category="h6">{item.header}</Text>
-          <Text category="s1">Publicerad på Skolplattformen</Text>
+          <Text category="s1">Skolplattformen</Text>
         </View>
       )}>
       <Image


### PR DESCRIPTION
This PR removes the "Publicerad på" in the news article subtitle and handles awkward line breaks in the tab navigation by auto-scaling the `font-size` if necessary.

Fixes #52 

| Before | After |
| ------ | ----- |
| ![Skärmavbild 2021-02-08 kl  16 15 11](https://user-images.githubusercontent.com/1478102/107239322-0846e780-6a29-11eb-844a-7062fec5d504.png) | ![Skärmavbild 2021-02-08 kl  16 15 23](https://user-images.githubusercontent.com/1478102/107239325-08df7e00-6a29-11eb-98c9-19f698332dd5.png) | 



