### PR TITLE
fix: contact page issues

### DIFF
--- a/packages/app/components/contactMenu.component.js
+++ b/packages/app/components/contactMenu.component.js
@@ -40,25 +40,25 @@ export const ContactMenu = ({contact, selected, setSelected}) => {
         <MenuGroup key={i} title={`${parent.firstname} ${parent.lastname}`}>
           <MenuItem
             accessoryLeft={CallIcon}
-            visible={!parent.mobile}
+            style={{display: parent.mobile ? 'flex' : 'none'}}
             title="Ring"
             onPress={(e) => Linking.openURL(`tel:${parent.mobile}`)}
           />
           <MenuItem
             accessoryLeft={SMSIcon}
-            visible={!parent.mobile}
+            style={{display: parent.mobile ? 'flex' : 'none'}}
             title="SMS"
             onPress={(e) => Linking.openURL(`sms:${parent.mobile}`)}
           />
           <MenuItem
             accessoryLeft={EmailIcon}
-            visible={!parent.email}
+            style={{display: parent.email ? 'flex' : 'none'}}
             title="Maila"
             onPress={(e) => Linking.openURL(`mailto:${parent.email}`)}
           />
           <MenuItem
             accessoryLeft={MapIcon}
-            visible={!parent.address}
+            style={{display: parent.address ? 'flex' : 'none'}}
             title="Hem"
             onPress={(e) =>
               Linking.openURL(`http://maps.apple.com/?daddr=${parent.address}`)

--- a/packages/app/components/contactMenu.component.js
+++ b/packages/app/components/contactMenu.component.js
@@ -11,12 +11,12 @@ import {
 export const ContactMenu = ({contact, selected, setSelected}) => {
   const [visible, setVisible] = React.useState(selected)
 
-  const contactIcon = (props) => <Icon {...props} name="phone-outline" />
+  const moreIcon = (props) => <Icon {...props} name="more-horizontal-outline" />
   const renderToggleButton = () => (
     <Button
       onPress={() => setVisible(true)}
       appearance="ghost"
-      accessoryLeft={contactIcon}
+      accessoryLeft={moreIcon}
     />
   )
 

--- a/packages/app/components/contactMenu.component.js
+++ b/packages/app/components/contactMenu.component.js
@@ -36,8 +36,11 @@ export const ContactMenu = ({contact, selected, setSelected}) => {
       anchor={renderToggleButton}
       backdropStyle={styles.backdrop}
       onBackdropPress={handleBackdropPress}>
-      {contact.guardians.map((parent, i) => (
-        <MenuGroup key={i} title={`${parent.firstname} ${parent.lastname}`}>
+      {contact.guardians.map((parent) => (
+        <MenuGroup
+          key={`${parent.firstname}-${parent.lastname}`}
+          title={`${parent.firstname} ${parent.lastname}`}
+          style={{position: 'relative', zIndex: 10}}>
           <MenuItem
             accessoryLeft={CallIcon}
             style={{display: parent.mobile ? 'flex' : 'none'}}


### PR DESCRIPTION
This PR changes the phone icon to the more-icon, the three dots, that most users should be familiar with from other apps. We also visually hide any contact information that is unavailable as well as handle click inside the contact menu better.

Fixes #48 

| Before | After |
| ------ | ----- |
| ![Skärmavbild 2021-02-09 kl  08 40 52](https://user-images.githubusercontent.com/1478102/107330980-8e5b4080-6ab2-11eb-85b7-0005d5d7e7d0.png) | ![Skärmavbild 2021-02-09 kl  08 40 36](https://user-images.githubusercontent.com/1478102/107330978-8d2a1380-6ab2-11eb-9904-13c4a6ce0c3a.png) | 