### PR TITLE
fix: handle missing social security number

### DIFF
--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -56,7 +56,9 @@ export const Login = ({navigation}) => {
   const [socialSecurityNumber, setSocialSecurityNumber] = React.useState(
     socialSecurityNumberCache,
   )
-  const isFemale = Personnummer.parse(socialSecurityNumberCache).isFemale()
+  const isFemale =
+    socialSecurityNumberCache &&
+    Personnummer.parse(socialSecurityNumberCache).isFemale()
 
   /* Initial load functions */
   useEffect(() => {

--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -57,8 +57,8 @@ export const Login = ({navigation}) => {
     socialSecurityNumberCache,
   )
   const isFemale =
-    socialSecurityNumberCache &&
-    Personnummer.parse(socialSecurityNumberCache).isFemale()
+    Personnummer.valid(socialSecurityNumber) &&
+    Personnummer.parse(socialSecurityNumber).isFemale()
 
   /* Initial load functions */
   useEffect(() => {

--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -491,8 +491,8 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
   react-native-cookies: ce50e42ace7cf0dd47769260ca5bbe8eee607e4e
-  react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
-  react-native-webview: a4751ec8f0a6a397026f22ed54c1efeec4540555
+  react-native-safe-area-context: 86612d2c9a9e94e288319262d10b5f93f0b395f5
+  react-native-webview: dbe6c1ad149740f0e2d84a963f1d3c3e77f2d99c
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0
@@ -503,8 +503,8 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  RNCAsyncStorage: 44539979e1f234262d64d3ce86ec21cceb1b2c5e
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCAsyncStorage: 0701cb7395f06d744184641241888a0eec0e2f2a
+  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: b6c9607e6fe47c1b6e2f1910d2acd46dd7ecea3a
@@ -514,4 +514,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7bddab1af6a6ea5128a2a6f6013968c5d4d00e7f
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1


### PR DESCRIPTION
In #59 I didn't catch the case where the social security number was `undefined` (not entered) or invalid (while typing). This PR checks the validity of the social security number before parsing it.