### PR TITLE
fix: handle dates and clicks on calendar items

### DIFF
--- a/packages/app/components/calendar.component.js
+++ b/packages/app/components/calendar.component.js
@@ -23,16 +23,14 @@ export const Calendar = ({calendar}) => {
     <Icon {...props} name={'calendar'} />
   )
 
-  const renderItem = ({item}) => {
-    return (
-      <ListItem
-        disabled={true}
-        title={`${item.title}`}
-        description={`${moment(item.startDate).fromNow()}`}
-        accessoryLeft={renderItemIcon(item.startDate, item.endDate)}
-      />
-    )
-  }
+  const renderItem = ({item}) => (
+    <ListItem
+      disabled={true}
+      title={`${item.title}`}
+      description={`${moment(item.startDate).fromNow()}`}
+      accessoryLeft={renderItemIcon(item.startDate, item.endDate)}
+    />
+  )
 
   return !calendar?.length ? (
     <View style={{flex: 1}}>

--- a/packages/app/components/calendar.component.js
+++ b/packages/app/components/calendar.component.js
@@ -23,13 +23,16 @@ export const Calendar = ({calendar}) => {
     <Icon {...props} name={'calendar'} />
   )
 
-  const renderItem = ({item}) => (
-    <ListItem
-      title={`${item.title}`}
-      description={`${moment(item.startDate).calendar()}`}
-      accessoryLeft={renderItemIcon(item.startDate, item.endDate)}
-    />
-  )
+  const renderItem = ({item}) => {
+    return (
+      <ListItem
+        disabled={true}
+        title={`${item.title}`}
+        description={`${moment(item.startDate).calendar()}`}
+        accessoryLeft={renderItemIcon(item.startDate, item.endDate)}
+      />
+    )
+  }
 
   return !calendar?.length ? (
     <View style={{flex: 1}}>

--- a/packages/app/components/calendar.component.js
+++ b/packages/app/components/calendar.component.js
@@ -28,7 +28,7 @@ export const Calendar = ({calendar}) => {
       <ListItem
         disabled={true}
         title={`${item.title}`}
-        description={`${moment(item.startDate).calendar()}`}
+        description={`${moment(item.startDate).fromNow()}`}
         accessoryLeft={renderItemIcon(item.startDate, item.endDate)}
       />
     )


### PR DESCRIPTION
This PR removes clicks from calendar items by adding the `disabled` prop. It also changes the date handling to `fromNow` instead of `calendar`. `calendar` formats the date separately when the date is close in time, but we only have the date as `YYYY-MM-DD` so we gain nothing from this formatting. The difference can be seen in the screenshots.

Fixes #51 

| Before | After |
| ------ | ----- |
| ![Skärmavbild 2021-02-10 kl  09 13 45](https://user-images.githubusercontent.com/1478102/107482734-64704f80-6b80-11eb-975a-be26084e16ec.png) | ![Skärmavbild 2021-02-10 kl  09 13 55](https://user-images.githubusercontent.com/1478102/107482743-663a1300-6b80-11eb-95eb-92ff8a73cbe9.png) | 
