### PR TITLE
fix: scroll overflow on child screens

### DIFF
--- a/packages/app/components/child.component.js
+++ b/packages/app/components/child.component.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import {StyleSheet, Linking} from 'react-native'
+import {StyleSheet} from 'react-native'
 import {
   TopNavigation,
   TopNavigationAction,
   Tab,
-  TabView,
-  OverflowMenu,
-  MenuItem,
+  TabBar,
   Layout,
   Text,
   Icon,
@@ -24,140 +22,147 @@ import {
   useCalendar,
   useSchedule,
 } from '@skolplattformen/api-hooks'
+import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs'
 
-export const Child = ({route, navigation}) => {
-  const {child, color, selectedTab} = route.params
-  const [selectedIndex, setSelectedIndex] = React.useState(selectedTab || 0)
+const {Navigator, Screen} = createMaterialTopTabNavigator()
+
+const ChildContext = React.createContext({})
+const useChild = () => React.useContext(ChildContext)
+
+const NewsScreen = () => {
+  const child = useChild()
+  const {data: news} = useNews(child)
+
+  return (
+    <Layout>
+      <NewsList news={news} />
+    </Layout>
+  )
+}
+
+const NotificationsScreen = () => {
+  const child = useChild()
   const {data: notifications, status: notificationsStatus} = useNotifications(
     child,
   )
-  const {data: news, status: newsStatus} = useNews(child)
-  const {data: classmates, status: classmatesStatus} = useClassmates(child)
-  const {data: calendar, status: calendarStatus} = useCalendar(child)
-  const {data: schedule, status: scheduleStatus} = useSchedule(
+
+  return (
+    <Layout>
+      <NotificationsList
+        notifications={notifications}
+        status={notificationsStatus}
+      />
+    </Layout>
+  )
+}
+
+const CalendarScreen = () => {
+  const child = useChild()
+  const {data: calendar} = useCalendar(child)
+  const {data: schedule} = useSchedule(
     child,
     DateTime.local(),
     DateTime.local().plus({days: 7}),
   )
-  const [menuVisible, setMenuVisible] = React.useState(false)
 
-  const NewsIcon = (props) => <Icon {...props} name="activity-outline" />
-  const NotificationsIcon = (props) => (
-    <Icon {...props} name="alert-circle-outline" />
+  return (
+    <Layout>
+      <Calendar calendar={[...(calendar ?? []), ...(schedule ?? [])]} />
+    </Layout>
   )
-  const CalendarIcon = (props) => <Icon {...props} name="calendar-outline" />
-  const ClassIcon = (props) => <Icon {...props} name="people-outline" />
-  const EditIcon = (props) => <Icon {...props} name="edit" />
-  const SettingsIcon = (props) => <Icon {...props} name="options-2-outline" />
-  const BackIcon = (props) => <Icon {...props} name="arrow-back" />
+}
 
-  const MenuIcon = (props) => <Icon {...props} name="more-vertical" />
+const ClassmatesScreen = () => {
+  const child = useChild()
+  const {data: classmates} = useClassmates(child)
+
+  return (
+    <Layout>
+      <Classmates classmates={classmates} />
+    </Layout>
+  )
+}
+
+const TabTitle = ({style, children}) => (
+  <Text adjustsFontSizeToFit numberOfLines={1} style={style}>
+    {children}
+  </Text>
+)
+
+const NewsIcon = (props) => <Icon {...props} name="activity-outline" />
+const NotificationsIcon = (props) => (
+  <Icon {...props} name="alert-circle-outline" />
+)
+const CalendarIcon = (props) => <Icon {...props} name="calendar-outline" />
+const ClassIcon = (props) => <Icon {...props} name="people-outline" />
+
+const TopTabBar = ({navigation, state}) => (
+  <TabBar
+    selectedIndex={state.index}
+    onSelect={(index) => navigation.navigate(state.routeNames[index])}>
+    <Tab
+      title={(props) => <TabTitle {...props}>Nyheter</TabTitle>}
+      icon={NewsIcon}
+    />
+    <Tab
+      title={(props) => <TabTitle {...props}>Notifieringar</TabTitle>}
+      icon={NotificationsIcon}
+    />
+    <Tab
+      title={(props) => <TabTitle {...props}>Kalender</TabTitle>}
+      icon={CalendarIcon}
+    />
+    <Tab
+      title={(props) => <TabTitle {...props}>Klassen</TabTitle>}
+      icon={ClassIcon}
+    />
+  </TabBar>
+)
+
+const TabNavigator = () => (
+  <Navigator tabBar={(props) => <TopTabBar {...props} />}>
+    <Screen name="Nyheter" component={NewsScreen} />
+    <Screen name="Notifieringar" component={NotificationsScreen} />
+    <Screen name="Kalender" component={CalendarScreen} />
+    <Screen name="Klassen" component={ClassmatesScreen} />
+  </Navigator>
+)
+
+export const Child = ({route, navigation}) => {
+  const {child, color} = route.params
+
+  const BackIcon = (props) => <Icon {...props} name="arrow-back" />
 
   const BackAction = () => (
     <TopNavigationAction icon={BackIcon} onPress={navigateBack} />
-  )
-
-  const TabTitle = ({style, children}) => (
-    <Text adjustsFontSizeToFit numberOfLines={1} style={style}>
-      {children}
-    </Text>
   )
 
   const navigateBack = () => {
     navigation.goBack()
   }
 
-  const toggleMenu = () => {
-    setMenuVisible(!menuVisible)
-  }
-
-  const renderMenuAction = () => (
-    <TopNavigationAction icon={MenuIcon} onPress={toggleMenu} />
-  )
-
-  const openSms = (child) => {
-    console.log('child', child)
-    Linking.openURL(`sms:+46730121740&body=${child.pnr}`)
-  }
-
-  const renderRightActions = (child) => () => (
-    <React.Fragment>
-      <OverflowMenu
-        anchor={renderMenuAction}
-        visible={menuVisible}
-        backdropStyle={styles.backdrop}
-        onBackdropPress={toggleMenu}>
-        <MenuItem
-          accessoryLeft={SettingsIcon}
-          title="Anmäl frånvaro"
-          onPress={() => openSms(child)}
-        />
-      </OverflowMenu>
-    </React.Fragment>
-  )
-
   return (
-    <SafeAreaView style={{flex: 1}} style={{...styles.topBar, color: color}}>
-      <TopNavigation
-        title={child.name.split('(')[0]}
-        alignment="center"
-        accessoryLeft={BackAction}
-        // accessoryRight={renderRightActions(child)}
-        style={styles.topBar}
-      />
-      <TabView
-        selectedIndex={selectedIndex}
-        onSelect={(index) => setSelectedIndex(index)}>
-        <Tab
-          title={(props) => <TabTitle {...props}>Nyheter</TabTitle>}
-          icon={NewsIcon}>
-          <Layout style={styles.tabContainer}>
-            <NewsList news={news} />
-          </Layout>
-        </Tab>
-        <Tab
-          title={(props) => <TabTitle {...props}>Notifieringar</TabTitle>}
-          icon={NotificationsIcon}>
-          <Layout style={styles.tabContainer}>
-            <NotificationsList
-              notifications={notifications}
-              status={notificationsStatus}
-            />
-          </Layout>
-        </Tab>
-        <Tab
-          title={(props) => <TabTitle {...props}>Kalender</TabTitle>}
-          icon={CalendarIcon}>
-          <Layout style={styles.tabContainer}>
-            <Calendar calendar={[...(calendar ?? []), ...(schedule ?? [])]} />
-          </Layout>
-        </Tab>
-        <Tab
-          title={(props) => <TabTitle {...props}>Klassen</TabTitle>}
-          icon={ClassIcon}>
-          <Layout style={styles.tabContainer}>
-            <Text category="h5">
-              Klass {classmates?.length ? classmates[0].className : ''}
-            </Text>
-            <Classmates classmates={classmates} />
-          </Layout>
-        </Tab>
-      </TabView>
+    <SafeAreaView style={{...styles.wrap, color}}>
+      <ChildContext.Provider value={child}>
+        <TopNavigation
+          title={child.name.split('(')[0]}
+          alignment="center"
+          accessoryLeft={BackAction}
+          style={styles.topBar}
+        />
+        <TabNavigator />
+      </ChildContext.Provider>
     </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
+  wrap: {
+    backgroundColor: '#fff',
+    flex: 1,
+  },
   topBar: {
     backgroundColor: '#fff',
-  },
-  tabContainer: {
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    justifyContent: 'flex-start',
-    paddingTop: 10,
-    paddingLeft: 10,
-    paddingBottom: 350,
   },
   backdrop: {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/packages/app/components/classmates.component.js
+++ b/packages/app/components/classmates.component.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {StyleSheet} from 'react-native'
-import {Divider, List, ListItem, Icon} from '@ui-kitten/components'
+import {Divider, List, ListItem, Icon, Text} from '@ui-kitten/components'
 import {ContactMenu} from './contactMenu.component'
 
 export const Classmates = ({classmates}) => {
@@ -31,6 +31,11 @@ export const Classmates = ({classmates}) => {
       style={styles.container}
       data={classmates}
       ItemSeparatorComponent={Divider}
+      ListHeaderComponent={
+        <Text category="h5" style={styles.listHeader}>
+          Klass {classmates?.length ? classmates[0].className : ''}
+        </Text>
+      }
       renderItem={renderItem}
     />
   )
@@ -39,5 +44,10 @@ export const Classmates = ({classmates}) => {
 const styles = StyleSheet.create({
   container: {
     width: '100%',
+  },
+  listHeader: {
+    backgroundColor: '#fff',
+    paddingTop: 10,
+    paddingLeft: 15,
   },
 })

--- a/packages/app/components/newsList.component.js
+++ b/packages/app/components/newsList.component.js
@@ -18,10 +18,10 @@ export const NewsList = ({news}) => {
 
 const styles = StyleSheet.create({
   container: {
+    height: '100%',
     width: '100%',
   },
   contentContainer: {
-    alignItems: 'stretch',
-    paddingRight: 10,
+    padding: 10,
   },
 })

--- a/packages/app/components/notificationsList.component.js
+++ b/packages/app/components/notificationsList.component.js
@@ -3,7 +3,7 @@ import {StyleSheet} from 'react-native'
 import {List} from '@ui-kitten/components'
 import {Notification} from './notification.component'
 
-export const NotificationsList = ({notifications, status}) => {
+export const NotificationsList = ({notifications}) => {
   return (
     <List
       style={styles.container}
@@ -18,11 +18,10 @@ export const NotificationsList = ({notifications, status}) => {
 
 const styles = StyleSheet.create({
   container: {
+    height: '100%',
     width: '100%',
   },
   contentContainer: {
-    alignItems: 'stretch',
-    paddingRight: 10,
-    paddingBottom: 330,
+    padding: 10,
   },
 })


### PR DESCRIPTION
This PR separates all screens for a child on separate routes. It seems like they were dependant on the height of each other before. This way layout is handled correctly without overflowing the `<SafeAreaView>` and without hacky `paddingBottom` adjustments.

The screenshots illustrate what the screen looked/look like when scrolled to the bottom.

Fixes #49, fixes #50 

| Before | After |
| ------ | ----- |
| ![Skärmavbild 2021-02-10 kl  10 49 42](https://user-images.githubusercontent.com/1478102/107493290-b9669280-6b8d-11eb-9e46-25338b0323b7.png) | ![Skärmavbild 2021-02-10 kl  10 48 53](https://user-images.githubusercontent.com/1478102/107493262-b370b180-6b8d-11eb-9a52-7980fdb1ecd7.png) | 
| ![Skärmavbild 2021-02-10 kl  10 49 38](https://user-images.githubusercontent.com/1478102/107493288-b9669280-6b8d-11eb-9ab1-7721a0d8d524.png) | ![Skärmavbild 2021-02-10 kl  10 48 57](https://user-images.githubusercontent.com/1478102/107493270-b53a7500-6b8d-11eb-91d2-a7230d9212c8.png) |
| ![Skärmavbild 2021-02-10 kl  10 49 34](https://user-images.githubusercontent.com/1478102/107493287-b8cdfc00-6b8d-11eb-92f7-5c4bb48d2177.png) | ![Skärmavbild 2021-02-10 kl  10 49 03](https://user-images.githubusercontent.com/1478102/107493276-b5d30b80-6b8d-11eb-80c2-e97da0dde587.png) |
| ![Skärmavbild 2021-02-10 kl  10 49 30](https://user-images.githubusercontent.com/1478102/107493282-b79ccf00-6b8d-11eb-84e0-a627c26c46f9.png) | ![Skärmavbild 2021-02-10 kl  10 49 07](https://user-images.githubusercontent.com/1478102/107493279-b66ba200-6b8d-11eb-8111-4c7efabd279a.png)|