### PR TITLE
feat: add Open Graph title, image and description

### DIFF
--- a/packages/site/components/Layout.js
+++ b/packages/site/components/Layout.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import React from 'react'
 import { Link as ScrollLink } from 'react-scroll'
 import favImg from '../assets/img/favicon.png'
+import logo from '../assets/img/logo.png'
 import { GA_TRACKING_ID } from './gtag'
 
 const Layout = (props) => {
@@ -26,6 +27,12 @@ const Layout = (props) => {
     <div>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta property="og:title" content="Öppna skolplattformen" />
+        <meta
+          property="og:description"
+          content="Öppna Skolplattformen är en app för iOS och Android som gör det enklare för föräldrar att komma åt uppgifter i Skolplattformen."
+        />
+        <meta property="og:image" content={logo} />
         <title>{props.pageTitle}</title>
         <link rel="shortcut icon" type="image/png" href={favImg} />
         <link


### PR DESCRIPTION
Noticed when sharing the link on Slack that it didn't expand the URL, due to missing OG metadata - added it here.

1. came up with a random description, feel free to change :)
2. took the best image I could find (logo from the header), but would probably be nicer with a custom one with a phone + app? 