### PR TITLE
fix: hantera långa namn i barnlistan

### DIFF
--- a/packages/app/components/childListItem.component.js
+++ b/packages/app/components/childListItem.component.js
@@ -58,11 +58,11 @@ export const ChildListItem = ({ navigation, child, color }) => {
   }
 
   const Header = (props) => (
-    <View {...props} style={{ flexDirection: 'row' }}>
-      <View style={{ margin: 20 }}>
+    <View {...props} style={{flexDirection: 'row', alignItems: 'center'}}>
+      <View style={{margin: 20, marginRight: 0}}>
         <Avatar source={require('../assets/avatar.png')} shape="square" />
       </View>
-      <View style={{ margin: 20 }}>
+      <View style={{margin: 20, flex: 1}}>
         <Text category="h6">{child.name?.split('(')[0]}</Text>
         <Text category="s1">{`${getClassName()}`}</Text>
       </View>


### PR DESCRIPTION
Den här PRn löser ett problem för första generationens iPhone SE där lång namn sträckte sig utanför skärmen. Har även tajtat till avstånden i headern något vilket ger bättre utseende och mer utrymme.

Fixes #104 

| Before | After |
| ------ | ----- |
| ![Skärmavbild 2021-02-15 kl  08 19 58](https://user-images.githubusercontent.com/1478102/107916789-310a3800-6f67-11eb-9406-e200d2528586.png) | ![Skärmavbild 2021-02-15 kl  08 19 40](https://user-images.githubusercontent.com/1478102/107916785-2fd90b00-6f67-11eb-8f47-7f19c237ca17.png) | 



