### PR TITLE
fix: använd statusfält med mörkt innehåll

### DIFF
--- a/packages/app/App.js
+++ b/packages/app/App.js
@@ -8,6 +8,7 @@ import init from '@skolplattformen/embedded-api'
 import {ApiProvider} from '@skolplattformen/api-hooks'
 import CookieManager from '@react-native-community/cookies'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import {StatusBar} from 'react-native'
 
 const api = init(fetch, () => {
   CookieManager.clearAll()
@@ -16,6 +17,7 @@ const api = init(fetch, () => {
 export default () => {
   return (
     <ApiProvider api={api} storage={AsyncStorage}>
+      <StatusBar barStyle="dark-content" />
       <IconRegistry icons={EvaIconsPack} />
       <ApplicationProvider {...eva} theme={{...eva.light, ...customization}}>
         <AppNavigator />


### PR DESCRIPTION
Denna PR fixar förhoppningsvis #103. Den gör så att statusfältet alltid ska ha mörkt innehåll.