### PR TITLE
fix: hantera ui för saknade datum i aviseringar

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Node
         uses: actions/setup-node@v1
+        with:
+          node-version: '14'
 
       - name: Install dependencies
         run: npx lerna bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Node
         uses: actions/setup-node@v1
+        with:
+          node-version: '14'
 
       - name: Install dependencies
         run: npx lerna bootstrap

--- a/packages/app/components/__tests__/Notification.test.js
+++ b/packages/app/components/__tests__/Notification.test.js
@@ -31,6 +31,8 @@ beforeEach(() => {
 test('renders subtitle with date', () => {
   const screen = setup()
 
+  screen.debug()
+
   expect(screen.getByText('Bedömning (för 17 minuter sedan)')).toBeTruthy()
 })
 
@@ -52,6 +54,8 @@ test('renders subtitle without category', () => {
   }
 
   const screen = setup({item: itemWithoutCategory})
+
+  screen.debug()
 
   expect(screen.getByText('(för 17 minuter sedan)')).toBeTruthy()
 })

--- a/packages/app/components/__tests__/Notification.test.js
+++ b/packages/app/components/__tests__/Notification.test.js
@@ -3,7 +3,6 @@ import {render} from '@testing-library/react-native'
 import {Notification} from '../notification.component.js'
 import {ApplicationProvider} from '@ui-kitten/components'
 import * as eva from '@eva-design/eva'
-import customization from '../../design/customization.json'
 import MockDate from 'mockdate'
 
 const defaultItem = {
@@ -19,7 +18,7 @@ const setup = (customProps = {}) => {
   }
 
   return render(
-    <ApplicationProvider {...eva} theme={{...eva.light, ...customization}}>
+    <ApplicationProvider {...eva} theme={eva.light}>
       <Notification {...props} />
     </ApplicationProvider>,
   )

--- a/packages/app/components/__tests__/Notification.test.js
+++ b/packages/app/components/__tests__/Notification.test.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import {render} from '@testing-library/react-native'
+import {Notification} from '../notification.component.js'
+import {ApplicationProvider} from '@ui-kitten/components'
+import * as eva from '@eva-design/eva'
+import customization from '../../design/customization.json'
+import MockDate from 'mockdate'
+
+const defaultItem = {
+  sender: 'Planering',
+  category: 'Bedömning',
+  dateCreated: '2021-02-15T09:13:28.484Z',
+}
+
+const setup = (customProps = {}) => {
+  const props = {
+    item: defaultItem,
+    ...customProps,
+  }
+
+  return render(
+    <ApplicationProvider {...eva} theme={{...eva.light, ...customization}}>
+      <Notification {...props} />
+    </ApplicationProvider>,
+  )
+}
+
+beforeEach(() => {
+  MockDate.set('2021-02-15T09:30:28.484Z')
+})
+
+test('renders subtitle with date', () => {
+  const screen = setup()
+
+  expect(screen.getByText('Bedömning (för 17 minuter sedan)')).toBeTruthy()
+})
+
+test('renders subtitle without date', () => {
+  const itemWithoutDate = {
+    ...defaultItem,
+    dateCreated: undefined,
+  }
+
+  const screen = setup({item: itemWithoutDate})
+
+  expect(screen.getByText('Bedömning')).toBeTruthy()
+})
+
+test('renders subtitle without category', () => {
+  const itemWithoutCategory = {
+    ...defaultItem,
+    category: undefined,
+  }
+
+  const screen = setup({item: itemWithoutCategory})
+
+  expect(screen.getByText('(för 17 minuter sedan)')).toBeTruthy()
+})

--- a/packages/app/components/__tests__/Notification.test.js
+++ b/packages/app/components/__tests__/Notification.test.js
@@ -31,8 +31,6 @@ beforeEach(() => {
 test('renders subtitle with date', () => {
   const screen = setup()
 
-  screen.debug()
-
   expect(screen.getByText('Bedömning (för 17 minuter sedan)')).toBeTruthy()
 })
 
@@ -54,8 +52,6 @@ test('renders subtitle without category', () => {
   }
 
   const screen = setup({item: itemWithoutCategory})
-
-  screen.debug()
 
   expect(screen.getByText('(för 17 minuter sedan)')).toBeTruthy()
 })

--- a/packages/app/components/notification.component.js
+++ b/packages/app/components/notification.component.js
@@ -22,7 +22,9 @@ export const Notification = ({item}) => {
           <View {...headerProps}>
             <Text category="h6">{item.sender}</Text>
             <Text category="s1">
-              {item.category ? `${item.category} ` : ''}({displayDate})
+              {item.category ? item.category : ''}
+              {item.category && displayDate ? ' ' : ''}
+              {displayDate ? `(${displayDate})` : ''}
             </Text>
           </View>
         )}>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,6 +69,9 @@
     "setupFilesAfterEnv": [
       "react-native-gesture-handler/jestSetup",
       "@testing-library/jest-native/extend-expect"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry|ui-kitten/.*)"
     ]
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,8 @@
     "@babel/core": "^7.12.13",
     "@babel/runtime": "^7.12.13",
     "@react-native-community/eslint-config": "^2.0.0",
+    "@testing-library/jest-native": "^3.4.3",
+    "@testing-library/react-native": "^7.1.0",
     "@types/luxon": "^1.25.1",
     "@types/react": "^16.8.24",
     "@types/react-native": "^0.63.43",
@@ -55,6 +57,7 @@
     "eslint": "^7.19.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.65.0",
+    "mockdate": "^3.0.2",
     "react-test-renderer": "16.13.1"
   },
   "resolutions": {
@@ -62,6 +65,10 @@
     "@types/react": "^16.8.24"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "setupFilesAfterEnv": [
+      "react-native-gesture-handler/jestSetup",
+      "@testing-library/jest-native/extend-expect"
+    ]
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -71,7 +71,7 @@
       "@testing-library/jest-native/extend-expect"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry|ui-kitten/.*)"
+      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry|@ui-kitten/.*)"
     ]
   }
 }

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -1486,6 +1486,25 @@
     merge-deep "^3.0.2"
     svgo "^1.2.2"
 
+"@testing-library/jest-native@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-3.4.3.tgz#fa6f902a442e2693f27563568a71e61bf11f8a53"
+  integrity sha512-CzHr3FMZCda/ChKEAjt9er9CHmIhgfKRHyeDrK3QoUdQUvlaFGER+WqGLqieJRdjRjpa2ecm+eNm2/+rPSFWkw==
+  dependencies:
+    chalk "^2.4.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    pretty-format "^24.0.0"
+    ramda "^0.26.1"
+    redent "^2.0.0"
+
+"@testing-library/react-native@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.1.0.tgz#6b168aac21522c8a5175461b350336fd79612ac9"
+  integrity sha512-ljVM9KZqG7BT/NFN6CHzdF6MNmM28+k7MEybFJ7FW1wVrhpiY4+hU9ypZ+hboO+MG3KpE2aFBzP4od3gu+Zzdg==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -3025,6 +3044,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
 diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
@@ -4242,6 +4266,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -4703,6 +4732,16 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
+jest-diff@^24.0.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -4945,6 +4984,16 @@ jest-leak-detector@^26.6.2:
   dependencies:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
@@ -6251,6 +6300,11 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment@>=2.0.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
@@ -6846,7 +6900,7 @@ prettier@^2.0.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -6866,7 +6920,7 @@ pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.6.2:
+pretty-format@^26.0.1, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -6970,6 +7024,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -7217,6 +7276,14 @@ recyclerlistview@^3.0.0:
     lodash.debounce "4.0.8"
     prop-types "15.5.8"
     ts-object-utils "0.0.5"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 redux@^4.0.5:
   version "4.0.5"
@@ -8024,6 +8091,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Den här PRn gömmer datumet om det saknas i en avisering. Den gör att vi inte får det trasiga UI:t med tomma parenteser i #99 men löser **inte** den underliggande buggen att datumet saknas.

Jag har också lagt till de första testerna och setup för dem i appen. Testerna körs i `jest` och använder `@testing-library/react-native`.