### PR TITLE
chore(site): använd next/image för bilder

### DIFF
--- a/packages/site/components/AppShots.js
+++ b/packages/site/components/AppShots.js
@@ -5,11 +5,12 @@ import screenshotChildNews from '../assets/img/screenshots/screenshot_child_news
 import screenshotChildNotifications from '../assets/img/screenshots/screenshot_child_notifications.png'
 import screenshotLogin from '../assets/img/screenshots/screenshot_login.png'
 import SectionTitle from './SectionTitle'
+import Image from 'next/image'
 
 const AppShots = () => {
   return (
     <section
-      className="max-w-6xl px-5 md:px-0 py-8 md:py-32 mx-auto"
+      className="max-w-6xl px-5 py-8 mx-auto md:px-0 md:py-32"
       id="screenshots"
     >
       <div className="max-w-2xl mx-auto">
@@ -20,18 +21,48 @@ const AppShots = () => {
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-6 gap-x-4">
-        <img src={screenshotLogin} alt="Inloggning med BankID" />
-        <img
-          src={screenshotChildren}
+        <Image
+          alt="Inloggning med BankID"
+          height={376}
+          layout="responsive"
+          src={screenshotLogin}
+          width={178}
+        />
+        <Image
           alt="Lista med dina barn i Stockholms Stad"
+          height={376}
+          layout="responsive"
+          src={screenshotChildren}
+          width={178}
         />
-        <img src={screenshotChildNews} alt="Barnets nyheter" />
-        <img
-          src={screenshotChildNotifications}
+        <Image
+          alt="Barnets nyheter"
+          height={376}
+          layout="responsive"
+          src={screenshotChildNews}
+          width={178}
+        />
+        <Image
           alt="Lista med barnets aviseringar"
+          height={376}
+          layout="responsive"
+          src={screenshotChildNotifications}
+          width={178}
         />
-        <img src={screenshotChildCalendar} alt="Barnets kalender" />
-        <img src={screenshotChildClass} alt="Barnets klasskompisar" />
+        <Image
+          alt="Barnets kalender"
+          height={376}
+          layout="responsive"
+          src={screenshotChildCalendar}
+          width={178}
+        />
+        <Image
+          alt="Barnets klasskompisar"
+          height={376}
+          layout="responsive"
+          src={screenshotChildClass}
+          width={178}
+        />
       </div>
     </section>
   )

--- a/packages/site/components/Testimonials.js
+++ b/packages/site/components/Testimonials.js
@@ -4,6 +4,7 @@ import imgNiels from '../assets/img/niels.jpg'
 import imgPer from '../assets/img/per.jpg'
 import imgFredrik from '../assets/img/wass.jpg'
 import Section from './Section'
+import Image from 'next/image'
 
 const testimonials = [
   {
@@ -46,11 +47,15 @@ const Testimonials = () => {
         >
           <div className="max-w-md px-8 py-4 bg-white rounded-lg shadow-lg">
             <div className="flex justify-center -mt-16 md:justify-start">
-              <img
-                alt={testimonial.name}
-                className="object-cover w-20 h-20 border-2 border-indigo-500 rounded-full"
-                src={testimonial.image}
-              />
+              <div className="object-cover w-20 h-20 border-2 border-indigo-500 rounded-full">
+                <Image
+                  alt={testimonial.name}
+                  className="object-cover rounded-full"
+                  height={80}
+                  src={testimonial.image}
+                  width={80}
+                />
+              </div>
             </div>
             <div>
               <p className="mt-2 text-gray-600">{testimonial.text}</p>


### PR DESCRIPTION
Genom att använda `next/image` så får vi lazy loading och bildoptimisering inbyggt. Det ger också en liten bump i performance i Lighthousetester.