### PR TITLE
fix: uppdatera testimonial med rätt text

### DIFF
--- a/packages/site/components/Testimonials.js
+++ b/packages/site/components/Testimonials.js
@@ -6,11 +6,11 @@ import imgFredrik from '../assets/img/wass.jpg'
 import Section from './Section'
 import Image from 'next/image'
 
-const testimonials = [
+export const testimonials = [
   {
     image: imgKarin,
     text:
-      'Det känns bra att mänskligheten nu befrias från upphandlingshaveriets bojor. Framtiden är här! Och den kostade nästan ingenting. Öppen data är kärlek.',
+      'Oftast när jag behöver kolla upp något är jag stressad och på språng. Om det tar tid att logga in och leta så struntar jag till sist i det.',
     name: 'Karin Nygårds',
     title: 'Lärare och förälder',
   },

--- a/packages/site/components/__tests__/Banner.test.js
+++ b/packages/site/components/__tests__/Banner.test.js
@@ -11,8 +11,6 @@ const setup = (customProps = {}) => {
 }
 
 test('renders a link to app store', () => {
-  global.alert = jest.fn()
-
   setup()
 
   expect(
@@ -24,8 +22,6 @@ test('renders a link to app store', () => {
 })
 
 test('renders a link to play store', () => {
-  global.alert = jest.fn()
-
   setup()
 
   expect(

--- a/packages/site/components/__tests__/DownloadButtons.test.js
+++ b/packages/site/components/__tests__/DownloadButtons.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import DownloadButtons from '../DownloadButtons'
+
+const setup = (customProps = {}) => {
+  const props = {
+    ...customProps,
+  }
+
+  return render(<DownloadButtons {...props} />)
+}
+
+test('renders a link to app store', () => {
+  setup()
+
+  expect(screen.getByRole('link', { name: /app store/i })).toHaveAttribute(
+    'href',
+    'https://apps.apple.com/se/app/%C3%B6ppna-skolplattformen/id1543853468'
+  )
+})
+
+test('renders a link to play store', () => {
+  setup()
+
+  expect(screen.getByRole('link', { name: /play store/i })).toHaveAttribute(
+    'href',
+    'https://play.google.com/store/apps/details?id=org.skolplattformen.app'
+  )
+})

--- a/packages/site/components/__tests__/Testimonials.test.js
+++ b/packages/site/components/__tests__/Testimonials.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Testimonials, { testimonials } from '../Testimonials'
+
+const setup = (customProps = {}) => {
+  const props = {
+    ...customProps,
+  }
+
+  return render(<Testimonials {...props} />)
+}
+
+test.each([testimonials.flatMap((testimonial) => Object.values(testimonial))])(
+  'displays all testimonials',
+  (_image, text, name, title) => {
+    setup()
+
+    expect(screen.getByAltText(name)).toBeInTheDocument()
+    expect(screen.getByText(text)).toBeInTheDocument()
+    expect(screen.getByText(name)).toBeInTheDocument()
+    expect(screen.getByText(title)).toBeInTheDocument()
+  }
+)


### PR DESCRIPTION
Den här PRn fixar texten för Karins testimonial. Den lägger även till tester för `<Testimonials>` och `<DownloadButtons>`.