### PR TITLE
Feature: automatic redirect from BankID on iOS

### DIFF
--- a/packages/app/android/app/src/main/AndroidManifest.xml
+++ b/packages/app/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,12 @@
             <category android:name="android.intent.category.LAUNCHER" />
             <category android:name="android.intent.category.DEFAULT" />
         </intent-filter>
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="oppnaskolplattformen" />
+        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -1,4 +1,5 @@
 {
   "name": "app",
-  "displayName": "app"
+  "displayName": "app",
+  "schema": "oppnaskolplattformen://"
 }

--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -88,7 +88,7 @@ export const Login = ({ navigation }) => {
     try {
       const bankIdUrl =
         Platform.OS === 'ios'
-          ? `https://app.bankid.com/?autostarttoken=${token.token}&redirect=null`
+          ? `https://app.bankid.com/?autostarttoken=${token.token}&redirect=${encodeURIComponent('oppnaskolplattformen://')}`
           : `bankid:///?autostarttoken=${token.token}&redirect=null`
       Linking.openURL(bankIdUrl)
     } catch (err) {

--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -22,6 +22,7 @@ import {
   View,
 } from 'react-native'
 import { useAsyncStorage } from 'use-async-storage'
+import {schema} from "../app.json"
 
 const funArguments = [
   'öppna',
@@ -88,7 +89,7 @@ export const Login = ({ navigation }) => {
     try {
       const bankIdUrl =
         Platform.OS === 'ios'
-          ? `https://app.bankid.com/?autostarttoken=${token.token}&redirect=${encodeURIComponent('oppnaskolplattformen://')}`
+          ? `https://app.bankid.com/?autostarttoken=${token.token}&redirect=${encodeURIComponent(schema)}`
           : `bankid:///?autostarttoken=${token.token}&redirect=null`
       Linking.openURL(bankIdUrl)
     } catch (err) {

--- a/packages/app/components/navigation.component.js
+++ b/packages/app/components/navigation.component.js
@@ -6,7 +6,7 @@ import { Child } from './child.component'
 import { Children } from './children.component'
 import { Login } from './login.component'
 import { NewsItem } from './newsItem.component'
-
+import { schema } from '../app.json'
 const { Navigator, Screen } = createStackNavigator()
 
 const HomeNavigator = () => (
@@ -19,7 +19,7 @@ const HomeNavigator = () => (
 )
 
 const linking = {
-  prefixes: ['oppnaskolplattformen://'],
+  prefixes: [schema],
   config: {
     screens: {
       Login: 'login',

--- a/packages/app/components/navigation.component.js
+++ b/packages/app/components/navigation.component.js
@@ -18,9 +18,17 @@ const HomeNavigator = () => (
   </Navigator>
 )
 
+const linking = {
+  prefixes: ['oppnaskolplattformen://'],
+  config: {
+    screens: {
+      Login: 'login',
+    },
+  },
+}
 export const AppNavigator = () => {
   return (
-    <NavigationContainer>
+    <NavigationContainer linking={linking}>
       <StatusBar />
       <HomeNavigator />
     </NavigationContainer>

--- a/packages/app/ios/app/AppDelegate.m
+++ b/packages/app/ios/app/AppDelegate.m
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
 
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
@@ -45,7 +46,6 @@ static void InitializeFlipper(UIApplication *application) {
   [self.window makeKeyAndVisible];
   return YES;
 }
-
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
@@ -54,5 +54,11 @@ static void InitializeFlipper(UIApplication *application) {
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 }
-
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
 @end
+

--- a/packages/app/ios/app/Info.plist
+++ b/packages/app/ios/app/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>oppnaskolplattformen</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>oppnaskolplattformen</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Added support for deep-linking with the prefix of "oppnaskolplattformen://" and added that url to the BankID-url. I'm not a parent so I can't really test to see if this works, but the deep-linking works so it shouldn't be any issues.

Closes #129