### PR TITLE
fix(android): uppdatera färg på statusbar

### DIFF
--- a/packages/app/App.js
+++ b/packages/app/App.js
@@ -17,7 +17,7 @@ const api = init(fetch, () => {
 export default () => {
   return (
     <ApiProvider api={api} storage={AsyncStorage}>
-      <StatusBar barStyle="dark-content" />
+      <StatusBar backgroundColor="#fff" barStyle="dark-content" translucent />
       <IconRegistry icons={EvaIconsPack} />
       <ApplicationProvider {...eva} theme={{ ...eva.light, ...customization }}>
         <AppNavigator />


### PR DESCRIPTION
Efter vi uppdaterade statusbar för iPhone till att använda mörkt innehåll i #122 så blev texten mörk på mörk bakgrund i Android. Denna PRn ger även Android mörk text på vit bakgrund.

| Before | After |
| ------ | ----- |
| ![Screenshot_1613725186](https://user-images.githubusercontent.com/1478102/108482287-975dc600-7299-11eb-88aa-05ad2b73b308.png) | ![Screenshot_1613724847](https://user-images.githubusercontent.com/1478102/108482291-988ef300-7299-11eb-9d02-3e6630f28e2b.png) | 