### PR TITLE
fix: göm ogiltiga datum i nyheter

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Set timezone
-        uses: actions/set-timezone-action@v1.1
+      - name: Setup timezone
+        uses: zcong1993/setup-timezone@master
         with:
-          timezoneLinux: "Europe/Stockholm"
+          timezone: Europe/Stockholm
 
       - name: Install dependencies
         run: npx lerna bootstrap

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -12,10 +12,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '14'
+
+      - name: Set timezone
+        uses: actions/set-timezone-action@v1.1
+        with:
+          timezoneLinux: "Europe/Stockholm"
 
       - name: Install dependencies
         run: npx lerna bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '14'
+
+      - name: Set timezone
+        uses: actions/set-timezone-action@v1.1
+        with:
+          timezoneLinux: "Europe/Stockholm"
 
       - name: Install dependencies
         run: npx lerna bootstrap

--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import { render } from '../../utils/testHelpers'
+import { NewsItem } from '../newsitem.component'
+import MockDate from 'mockdate'
+import { fireEvent } from '@testing-library/react-native'
+import { useNewsDetails, useApi } from '@skolplattformen/api-hooks'
+
+jest.mock('@skolplattformen/api-hooks')
+
+const defaultNewsItem = {
+  author: 'Köket',
+  fullImageUrl: 'test.png',
+  header: 'K-bullar!',
+  published: '2021-02-15T09:13:28.484Z',
+  modified: '2021-02-15T09:13:28.484Z',
+}
+
+let navigation
+
+const setup = (customProps = { newsItem: {} }) => {
+  useApi.mockReturnValue({ api: { getSessionCookie: jest.fn() } })
+  useNewsDetails.mockReturnValue({
+    data: {
+      body: 'Nu blir det köttbullar',
+    },
+  })
+
+  navigation = {
+    goBack: jest.fn(),
+  }
+
+  const newsItem = {
+    ...defaultNewsItem,
+    ...customProps.newsItem,
+  }
+
+  const props = {
+    navigation,
+    route: {
+      params: {
+        child: { id: 1 },
+        newsItem,
+      },
+    },
+    ...customProps,
+  }
+
+  return render(<NewsItem {...props} />)
+}
+
+beforeEach(() => {
+  MockDate.set('2021-02-15T09:30:28.484Z')
+})
+
+test('gets article details using useNewsDetails', () => {
+  setup()
+
+  expect(useNewsDetails).toHaveBeenCalledWith({ id: 1 }, defaultNewsItem)
+})
+
+test('renders an article', () => {
+  const screen = setup()
+
+  expect(screen.getByText(/k-bullar!/i)).toBeTruthy()
+  expect(screen.getByText(/nu blir det köttbullar/i)).toBeTruthy()
+  expect(screen.getByText('Publicerad: 15 feb. 2021 10:13')).toBeTruthy()
+  expect(screen.getByText('Uppdaterad: 15 feb. 2021 10:13')).toBeTruthy()
+})
+
+test('renders an article without published date if date is invalid', () => {
+  const newsItemWithoutPublishedDate = {
+    ...defaultNewsItem,
+    published: null,
+  }
+
+  const screen = setup({ newsItem: newsItemWithoutPublishedDate })
+
+  expect(screen.getByText(/k-bullar!/i)).toBeTruthy()
+  expect(screen.getByText(/nu blir det köttbullar/i)).toBeTruthy()
+  expect(screen.getByText('Uppdaterad: 15 feb. 2021 10:13')).toBeTruthy()
+  expect(screen.queryByText('Publicerad: Invalid DateTime')).toBeFalsy()
+})
+
+test('renders an article without modified date if date is invalid', () => {
+  const newsItemWithoutPublishedDate = {
+    ...defaultNewsItem,
+    modified: null,
+  }
+
+  const screen = setup({ newsItem: newsItemWithoutPublishedDate })
+
+  expect(screen.getByText(/k-bullar!/i)).toBeTruthy()
+  expect(screen.getByText(/nu blir det köttbullar/i)).toBeTruthy()
+  expect(screen.getByText('Publicerad: 15 feb. 2021 10:13')).toBeTruthy()
+  expect(screen.queryByText('Uppdaterad: Invalid DateTime')).toBeFalsy()
+})
+
+test('handles navigating back to child view', () => {
+  const screen = setup()
+
+  fireEvent.press(screen.getByA11yLabel('Tillbaka till barn'))
+
+  expect(navigation.goBack).toHaveBeenCalled()
+})

--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render } from '../../utils/testHelpers'
 import { NewsItem } from '../newsItem.component'
-import MockDate from 'mockdate'
 import { fireEvent } from '@testing-library/react-native'
 import { useNewsDetails, useApi } from '@skolplattformen/api-hooks'
 
@@ -48,10 +47,6 @@ const setup = (customProps = { newsItem: {} }) => {
   return render(<NewsItem {...props} />)
 }
 
-beforeEach(() => {
-  MockDate.set('2021-02-15T09:30:28.484Z')
-})
-
 test('gets article details using useNewsDetails', () => {
   setup()
 
@@ -60,8 +55,6 @@ test('gets article details using useNewsDetails', () => {
 
 test('renders an article', () => {
   const screen = setup()
-
-  screen.debug()
 
   expect(screen.getByText(/k-bullar!/i)).toBeTruthy()
   expect(screen.getByText(/nu blir det köttbullar/i)).toBeTruthy()
@@ -72,7 +65,7 @@ test('renders an article', () => {
 test('renders an article without published date if date is invalid', () => {
   const newsItemWithoutPublishedDate = {
     ...defaultNewsItem,
-    published: '__invalid_date__',
+    published: null,
   }
 
   const screen = setup({ newsItem: newsItemWithoutPublishedDate })
@@ -86,7 +79,7 @@ test('renders an article without published date if date is invalid', () => {
 test('renders an article without modified date if date is invalid', () => {
   const newsItemWithoutPublishedDate = {
     ...defaultNewsItem,
-    modified: '__invalid_date__',
+    modified: null,
   }
 
   const screen = setup({ newsItem: newsItemWithoutPublishedDate })

--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -70,7 +70,7 @@ test('renders an article', () => {
 test('renders an article without published date if date is invalid', () => {
   const newsItemWithoutPublishedDate = {
     ...defaultNewsItem,
-    published: null,
+    published: '__invalid_date__',
   }
 
   const screen = setup({ newsItem: newsItemWithoutPublishedDate })
@@ -84,7 +84,7 @@ test('renders an article without published date if date is invalid', () => {
 test('renders an article without modified date if date is invalid', () => {
   const newsItemWithoutPublishedDate = {
     ...defaultNewsItem,
-    modified: null,
+    modified: '__invalid_date__',
   }
 
   const screen = setup({ newsItem: newsItemWithoutPublishedDate })

--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '../../utils/testHelpers'
-import { NewsItem } from '../newsitem.component'
+import { NewsItem } from '../newsItem.component'
 import MockDate from 'mockdate'
 import { fireEvent } from '@testing-library/react-native'
 import { useNewsDetails, useApi } from '@skolplattformen/api-hooks'

--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -61,6 +61,8 @@ test('gets article details using useNewsDetails', () => {
 test('renders an article', () => {
   const screen = setup()
 
+  screen.debug()
+
   expect(screen.getByText(/k-bullar!/i)).toBeTruthy()
   expect(screen.getByText(/nu blir det köttbullar/i)).toBeTruthy()
   expect(screen.getByText('Publicerad: 15 feb. 2021 10:13')).toBeTruthy()

--- a/packages/app/components/newsItem.component.js
+++ b/packages/app/components/newsItem.component.js
@@ -8,14 +8,15 @@ import {
   TopNavigation,
   TopNavigationAction,
 } from '@ui-kitten/components'
-import { DateTime } from 'luxon'
 import React from 'react'
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
 import { Image } from './image.component'
 import { Markdown } from './markdown.component'
+import moment from 'moment'
+import 'moment/locale/sv'
 
 const displayDate = (date) =>
-  DateTime.fromISO(date).setLocale('sv').toLocaleString(DateTime.DATETIME_MED)
+  moment(date).locale('sv').format('DD MMM. YYYY HH:mm')
 
 const BackIcon = (props) => <Icon {...props} name="arrow-back" />
 

--- a/packages/app/components/newsItem.component.js
+++ b/packages/app/components/newsItem.component.js
@@ -28,23 +28,30 @@ export const NewsItem = ({ navigation, route }) => {
   }
 
   const BackAction = () => (
-    <TopNavigationAction icon={BackIcon} onPress={navigateBack} />
+    <TopNavigationAction
+      accessibilityLabel="Tillbaka till barn"
+      icon={BackIcon}
+      onPress={navigateBack}
+    />
   )
+
+  const publishedAt = displayDate(newsItem.published)
+  const modifiedAt = displayDate(newsItem.modified)
 
   const renderItemHeader = (headerProps) => (
     <View {...headerProps}>
       <Text category="h3">{newsItem.header}</Text>
       <Image src={newsItem.fullImageUrl} style={styles.image} />
-      <Text category="s1" appearance="hint">
-        {newsItem.published
-          ? `Publicerad: ${displayDate(newsItem.published)}`
-          : ''}
-      </Text>
-      <Text category="s1" appearance="hint">
-        {newsItem.modified
-          ? `Uppdaterad: ${displayDate(newsItem.modified)}`
-          : ''}
-      </Text>
+      {publishedAt !== 'Invalid DateTime' && (
+        <Text category="s1" appearance="hint">
+          Publicerad: {publishedAt}
+        </Text>
+      )}
+      {modifiedAt !== 'Invalid DateTime' && (
+        <Text category="s1" appearance="hint">
+          Uppdaterad: {modifiedAt}
+        </Text>
+      )}
     </View>
   )
 


### PR DESCRIPTION
Detta är en follow-up till #110 där tomma datum gömdes i nyheterna. Om datumet fanns men hade fel format så gömdes det inte, t.ex. `2020-08-16T21:10:00.000+02:0`. Den här PRn tar hand om saknade datum och felaktiga format genom att först försöka parsea datumet. Jag har även lagt till tester för hela `<NewsItem>`.