### PR TITLE
fix: hantera bilder med absolut url i markdown

### DIFF
--- a/packages/app/components/markdown.component.js
+++ b/packages/app/components/markdown.component.js
@@ -7,11 +7,11 @@ import { Image } from './image.component'
 const rules = {
   image: (node) => {
     const { src } = node.attributes
-
+    const url = src.startsWith('/') ? `https://elevstockholm.sharepoint.com${src}` : src;
     return (
       <Image
         key={src}
-        src={`https://elevstockholm.sharepoint.com${src}`}
+        src={url}
         style={{ width: '100%', minHeight: 300 }}
       />
     )


### PR DESCRIPTION
The "src" of images in news was always prepended by the host name of skolplattformen, breaking images where the src was a complete url. This PR fixes the issue. Only when the src starts with "/" it's prepended, otherwise it's left as it is.