### PR TITLE
fix: 🐛 remove applicationSuffix for Android debug variant

### DIFF
--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -160,7 +160,6 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
-            applicationIdSuffix ".debug"
         }
         release {
             // Caution! In production, you need to generate your own keystore file.


### PR DESCRIPTION
RN can't handle varying appllicationIds when launching. Removing this so
the app is launched correctly with yarn run android

✅ Closes: #130