### PR TITLE
chore: uppdatera styling för en nyhet

### DIFF
--- a/packages/app/components/__tests__/NewsItem.test.js
+++ b/packages/app/components/__tests__/NewsItem.test.js
@@ -65,7 +65,7 @@ test('renders an article', () => {
 test('renders an article without published date if date is invalid', () => {
   const newsItemWithoutPublishedDate = {
     ...defaultNewsItem,
-    published: null,
+    published: '2020-08-16T21:10:00.000+02:0',
   }
 
   const screen = setup({ newsItem: newsItemWithoutPublishedDate })

--- a/packages/app/components/newsItem.component.js
+++ b/packages/app/components/newsItem.component.js
@@ -70,7 +70,9 @@ export const NewsItem = ({ navigation, route }) => {
           >
             {data.body}
           </Markdown>
-          <Image src={newsItem.fullImageUrl} style={styles.image} />
+          {newsItem.fullImageUrl && (
+            <Image src={newsItem.fullImageUrl} style={styles.image} />
+          )}
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/packages/app/components/newsItem.component.js
+++ b/packages/app/components/newsItem.component.js
@@ -1,8 +1,6 @@
 import { useNewsDetails } from '@skolplattformen/api-hooks'
 import {
-  Card,
   Divider,
-  Layout,
   Text,
   TopNavigation,
   TopNavigationAction,
@@ -17,6 +15,8 @@ import { Markdown } from './markdown.component'
 
 const displayDate = (date) =>
   moment(date).locale('sv').format('DD MMM. YYYY HH:mm')
+
+const dateIsValid = (date) => moment(date, moment.ISO_8601).isValid()
 
 export const NewsItem = ({ navigation, route }) => {
   const { newsItem, child } = route.params
@@ -34,28 +34,8 @@ export const NewsItem = ({ navigation, route }) => {
     />
   )
 
-  const publishedAt = displayDate(newsItem.published)
-  const modifiedAt = displayDate(newsItem.modified)
-
-  const renderItemHeader = (headerProps) => (
-    <View {...headerProps}>
-      <Text category="h3">{newsItem.header}</Text>
-      <Image src={newsItem.fullImageUrl} style={styles.image} />
-      {publishedAt !== 'Invalid DateTime' && (
-        <Text category="s1" appearance="hint">
-          Publicerad: {publishedAt}
-        </Text>
-      )}
-      {modifiedAt !== 'Invalid DateTime' && (
-        <Text category="s1" appearance="hint">
-          Uppdaterad: {modifiedAt}
-        </Text>
-      )}
-    </View>
-  )
-
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#fff' }}>
+    <SafeAreaView style={styles.safeArea}>
       <TopNavigation
         title="Nyhet från Skolplattformen"
         alignment="center"
@@ -63,40 +43,78 @@ export const NewsItem = ({ navigation, route }) => {
       />
       <Divider />
 
-      <Layout style={styles.topContainer} level="1">
-        <ScrollView>
-          <Card
-            style={styles.card}
-            header={(headerProps) => renderItemHeader(headerProps, data)}
+      <ScrollView
+        contentContainerStyle={styles.article}
+        style={styles.scrollView}
+      >
+        <Text style={styles.title}>{newsItem.header}</Text>
+        {dateIsValid(newsItem.published) && (
+          <Text style={[styles.subtitle, styles.published]}>
+            <Text style={styles.strong}>Publicerad:</Text>{' '}
+            {displayDate(newsItem.published)}
+          </Text>
+        )}
+        {dateIsValid(newsItem.modified) && (
+          <Text style={styles.subtitle}>
+            <Text style={styles.strong}>Uppdaterad:</Text>{' '}
+            {displayDate(newsItem.modified)}
+          </Text>
+        )}
+        <View style={styles.body}>
+          <Markdown
+            style={{
+              body: { color: '#1F2937', fontSize: 16, lineHeight: 26 },
+              heading1: { color: '#1F2937', fontSize: 20 },
+              heading2: { color: '#1F2937', fontSize: 18 },
+            }}
           >
-            <Markdown
-              style={{
-                body: { color: 'black', fontSize: 17, lineHeight: 23 },
-                heading1: { color: 'black' },
-              }}
-            >
-              {data.body}
-            </Markdown>
-          </Card>
-        </ScrollView>
-      </Layout>
+            {data.body}
+          </Markdown>
+          <Image src={newsItem.fullImageUrl} style={styles.image} />
+        </View>
+      </ScrollView>
     </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
   topContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
-  card: {
+  article: {
+    padding: 20,
+  },
+  scrollView: {
     flex: 1,
-    margin: 2,
-    marginBottom: 50,
   },
   image: {
     width: '100%',
     minHeight: 300,
-    marginBottom: 5,
+    marginTop: 16,
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  subtitle: {
+    color: '#6B7280',
+    fontSize: 12,
+  },
+  strong: {
+    color: '#6B7280',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  published: {
+    marginBottom: 4,
+  },
+  body: {
+    marginTop: 16,
   },
 })


### PR DESCRIPTION
Den här PRn uppdaterar styling av en nyhetssida. Den fixar till ett gäng textstorlekar för att lägga mindre tyngd vid vissa delar och flyttar även ner bilden efter texten. Den hanterar även datum genom att första köra dem genom `moment().isValid()` för att verkligen se om datumet går att parsea.

Fixes #76 i alla fall som en enkel lösning att först och främst visa textinnehållet och sekundärt visa bilden.

| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 11 - 2021-02-20 at 14 05 16](https://user-images.githubusercontent.com/1478102/108596392-0106ce80-7385-11eb-82e0-a7282292e00e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-02-20 at 14 04 25](https://user-images.githubusercontent.com/1478102/108596389-ff3d0b00-7384-11eb-81cc-636d51a112aa.png) | 