### PR TITLE
chore: automatiskt changelog via semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,13 @@ jobs:
         run: yarn test
         env:
           CI: true
+
+      - name: Create release using semantic-release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 17.1.1
+          extra_plugins: |
+            @semantic-release/changelog@5.0.1
+            @semantic-release/git@9.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,5 @@
 {
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    "@semantic-release/git"
+  ]
+}
+


### PR DESCRIPTION
Eftersom vi redan använder `semantic-release`-commits så kan vi enkelt få en changelog som uppdateras med ändringar efter bygge i `main`.

Skapades med hjälp av [`supreme github-actions --no-npm`](https://github.com/opendevtools/supreme#github-actions) och justerades in i vår befintliga `release.yml`