### PR TITLE
fix: 🐛 Redirect från BankId appen funkar nu

### DIFF
--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -104,8 +104,8 @@ export const Login = ({ navigation }) => {
       const redirect = loginMethodIndex === 0 ? encodeURIComponent(schema) : ''
       const bankIdUrl =
         Platform.OS === 'ios'
-          ? `https://app.bankid.com/?autostarttoken=${token.token}&redirect=${redirect}`
-          : `bankid:///?autostarttoken=${token.token}&redirect=null`
+          ? `https://app.bankid.com/?autostarttoken=${token}&redirect=${redirect}`
+          : `bankid:///?autostarttoken=${token}&redirect=null`
       Linking.openURL(bankIdUrl)
     } catch (err) {
       setError('Öppna BankID manuellt')


### PR DESCRIPTION
Trots allt fina jobb av @arvidnilber i #139 så var autostarttoken alltid "undefined" och redirect funkade inte från BankId appen.  Den här lilla fixen fixar det!