### PR TITLE
fix: använd korrekt komponent för github-länk

### DIFF
--- a/packages/site/components/Footer.js
+++ b/packages/site/components/Footer.js
@@ -17,10 +17,12 @@ const Footer = () => {
           <p className="mb-5">
             Skolplattformen utvecklas av föräldrar för föräldrar. Vill du hjälpa
             till? Kom till vår{' '}
-            <a href="https://github.com/kolplattformen">Github</a>, där finns
-            all källkod och även uppgifter att ta tag i, vi behöver hjälp med
-            allt från illustrationer, UX, design och programmering. Vi har även
-            en Discord där vi hjälps åt.
+            <Link.External href="https://github.com/kolplattformen">
+              Github
+            </Link.External>
+            , där finns all källkod och även uppgifter att ta tag i, vi behöver
+            hjälp med allt från illustrationer, UX, design och programmering. Vi
+            har även en Discord där vi hjälps åt.
           </p>
           <Link.External href="mailto:info@skolplattformen.org">
             info@skolplattformen.org


### PR DESCRIPTION
Tjenixen,

Här kommer en minifix från Medelpad. Riktigt bra jobbat med detta. :)

Det var inte tydligt att github var en länk i footern tidigare. Visade sig att det räckte med ett byte till `Link.External` istället för en vanlig `<a>`.

![before_after](https://user-images.githubusercontent.com/4541038/110323713-47129200-8015-11eb-840b-27f1b67fa866.png)

/J

