### PR TITLE
fix: använd korrekt tusen-separator för miljarden

### DIFF
--- a/packages/site/components/FunFacts.js
+++ b/packages/site/components/FunFacts.js
@@ -37,13 +37,16 @@ const FunFacts = () => {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-y-5">
         {FUNFACTS_DATA.map((funfact) => (
           <div className="text-center" key={funfact.title}>
-            <span className="text-5xl text-indigo-500">
+            <span className="text-4xl sm:text-5xl text-indigo-500 whitespace-nowrap">
               <VisibilitySensor
                 onChange={onVisibilityChange}
                 offset={{ top: 10 }}
                 delayedCall
               >
-                <CountUp end={counter.startCounter ? funfact.count : 0} />
+                <CountUp
+                  end={counter.startCounter ? funfact.count : 0}
+                  separator=" "
+                />
               </VisibilitySensor>
             </span>
             <p className="text-gray-700">{funfact.title}</p>


### PR DESCRIPTION
Hej,

Nu skrivs det ut 1000000000, vilket gör det svårt att se exakt hur mycket pengar som Stockholms stad har lagt på denna 🔥.

Ändrade till 1 000 000 000 så att det är lättare att se.

- Minskade typografin på mobil för att fungera på 320px bred skärm
- La till whitewrap-no-wrap så att det inte hoppar omkring

/J