### PR TITLE
Add property to enable shared cookies on webview (fix #192 SSO mot Unikum)

### DIFF
--- a/packages/app/components/__tests__/Children.test.js
+++ b/packages/app/components/__tests__/Children.test.js
@@ -72,7 +72,7 @@ test('renders child in preschool', () => {
   const screen = setup()
 
   expect(screen.getByText('Test Testsson')).toBeTruthy()
-  expect(screen.getByText('Förskoleklass')).toBeTruthy()
+  expect(screen.getByText('Fritids')).toBeTruthy()
 })
 
 test('renders child in elementary school', () => {
@@ -190,7 +190,7 @@ test('handles multiple statuses for a child', () => {
   const screen = setup()
 
   expect(screen.getByText('Test Testsson')).toBeTruthy()
-  expect(screen.getByText('Gymnasiet, Grundskolan, Förskoleklass')).toBeTruthy()
+  expect(screen.getByText('Gymnasiet, Grundskolan, Fritids')).toBeTruthy()
 })
 
 test('says if there is nothing new this week', () => {

--- a/packages/app/components/childListItem.component.tsx
+++ b/packages/app/components/childListItem.component.tsx
@@ -70,7 +70,8 @@ export const ChildListItem = ({ child, color }: ChildListItemProps) => {
     const abbrevations = {
       G: 'Gymnasiet', // ? i'm guessing here
       GR: 'Grundskolan',
-      F: 'Förskoleklass',
+      F: 'Fritids',
+      FS: 'Förskola',
     }
 
     return child.status

--- a/packages/app/components/modalWebView.component.tsx
+++ b/packages/app/components/modalWebView.component.tsx
@@ -17,17 +17,15 @@ export const ModalWebView = ({ url, onClose }: ModalWebViewProps) => {
   const { api } = useApi()
   const [headers, setHeaders] = useState()
 
-  const getHeaders = async (url) => {
-    if (sharedCookiesEnabled) return
-    // eslint-disable-next-line no-shadow
-    const { headers } = await api.getSession(url)
-    setHeaders(headers)
-  }
-
   useEffect(() => {
-    getHeaders()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [url])
+    const getHeaders = async (urlToGetSessionFor) => {
+      if (sharedCookiesEnabled) return
+      const { headers: newHeaders } = await api.getSession(urlToGetSessionFor)
+      setHeaders(newHeaders)
+    }
+
+    getHeaders(url)
+  }, [url, sharedCookiesEnabled, api])
 
   const uri = new URI(url)
 

--- a/packages/app/components/modalWebView.component.tsx
+++ b/packages/app/components/modalWebView.component.tsx
@@ -60,6 +60,7 @@ export const ModalWebView = ({
             style={styles.webview}
             source={{ uri: url, headers }}
             sharedCookiesEnabled={sharedCookiesEnabled}
+            thirdPartyCookiesEnabled={sharedCookiesEnabled}
           />
         )}
       </SafeAreaView>

--- a/packages/app/components/modalWebView.component.tsx
+++ b/packages/app/components/modalWebView.component.tsx
@@ -17,9 +17,11 @@ export const ModalWebView = ({ url, onClose }: ModalWebViewProps) => {
   const { api } = useApi()
   const [headers, setHeaders] = useState()
 
-  const getHeaders = async () => {
-    const { headers: updatedHeaders } = await api.getSession(url)
-    setHeaders(updatedHeaders)
+  const getHeaders = async (url) => {
+    if (sharedCookiesEnabled) return
+    // eslint-disable-next-line no-shadow
+    const { headers } = await api.getSession(url)
+    setHeaders(headers)
   }
 
   useEffect(() => {
@@ -50,8 +52,12 @@ export const ModalWebView = ({ url, onClose }: ModalWebViewProps) => {
             </TouchableOpacity>
           </View>
         </View>
-        {headers && (
-          <WebView style={styles.webview} source={{ uri: url, headers }} />
+        {(headers || sharedCookiesEnabled) && (
+          <WebView
+            style={styles.webview}
+            source={{ uri: url, headers }}
+            sharedCookiesEnabled={sharedCookiesEnabled}
+          />
         )}
       </SafeAreaView>
     </Modal>

--- a/packages/app/components/modalWebView.component.tsx
+++ b/packages/app/components/modalWebView.component.tsx
@@ -9,16 +9,21 @@ import { CloseIcon } from './icon.component'
 
 interface ModalWebViewProps {
   url: string
+  sharedCookiesEnabled: boolean
   onClose: () => void
 }
 
-export const ModalWebView = ({ url, onClose }: ModalWebViewProps) => {
+export const ModalWebView = ({
+  url,
+  onClose,
+  sharedCookiesEnabled,
+}: ModalWebViewProps) => {
   const [modalVisible, setModalVisible] = React.useState(true)
   const { api } = useApi()
   const [headers, setHeaders] = useState()
 
   useEffect(() => {
-    const getHeaders = async (urlToGetSessionFor) => {
+    const getHeaders = async (urlToGetSessionFor: string) => {
       if (sharedCookiesEnabled) return
       const { headers: newHeaders } = await api.getSession(urlToGetSessionFor)
       setHeaders(newHeaders)

--- a/packages/app/components/notification.component.tsx
+++ b/packages/app/components/notification.component.tsx
@@ -19,6 +19,10 @@ export const Notification = ({ item }: NotificationProps) => {
     ? moment(item.dateCreated).fromNow()
     : null
 
+  const sharedCookiesEnabled = () => {
+    return item.url && item.url.startsWith('https://start.unikum.net/')
+  }
+
   return (
     <>
       <Card
@@ -37,7 +41,13 @@ export const Notification = ({ item }: NotificationProps) => {
       >
         <Text>{item.message}</Text>
       </Card>
-      {isOpen && <ModalWebView url={item.url} onClose={close} />}
+      {isOpen && (
+        <ModalWebView
+          url={item.url}
+          onClose={close}
+          sharedCookiesEnabled={sharedCookiesEnabled()}
+        />
+      )}
     </>
   )
 }

--- a/packages/app/components/notification.component.tsx
+++ b/packages/app/components/notification.component.tsx
@@ -19,9 +19,9 @@ export const Notification = ({ item }: NotificationProps) => {
     ? moment(item.dateCreated).fromNow()
     : null
 
-  const sharedCookiesEnabled = () => {
-    return item.url && item.url.startsWith('https://start.unikum.net/')
-  }
+  const sharedCookiesEnabled: boolean = Boolean(
+    item.url && item.url.startsWith('https://start.unikum.net/')
+  )
 
   return (
     <>
@@ -45,7 +45,7 @@ export const Notification = ({ item }: NotificationProps) => {
         <ModalWebView
           url={item.url}
           onClose={close}
-          sharedCookiesEnabled={sharedCookiesEnabled()}
+          sharedCookiesEnabled={sharedCookiesEnabled}
         />
       )}
     </>


### PR DESCRIPTION
Fixar #192 genom att tillåta sharedCookies på webvyn. 

Unikum använder SSO som funkar såhär:
1. Länken i notfieringen går till start.unikum.net. 
2. Redirect till login001.stockholm.se. Här behövs SMSESSION cookien för att komma vidare
3. Ett formulär skickas tillbaka som webläsaren auto-postar (med Javascript) tillbaka till start.unikum.net
4. Nu får man en login-cookie från Unikum och allt rullar på

Det enklaste sättet att få det att funka var att tillåta delade cookies på WebView och sen låta allt funka automatiskt.

Funkar i IOS, har inte testat på Android (har ingen miljö uppsatt)