### PR TITLE
Feat/svep tillbaka logout

### DIFF
--- a/packages/app/components/logout.component.js
+++ b/packages/app/components/logout.component.js
@@ -3,6 +3,7 @@ import { Button, Text } from '@ui-kitten/components'
 import Personnummer from 'personnummer'
 import React, { useState } from 'react'
 import { Image, StyleSheet, View } from 'react-native'
+import { Directions, FlingGestureHandler } from 'react-native-gesture-handler'
 import { CheckIcon, CloseOutlineIcon } from './icon.component'
 
 const imageSources = {
@@ -37,33 +38,39 @@ export const Logout = ({ navigation }) => {
   }
 
   return (
-    <>
-      <Image
-        source={imageSources[gender]}
-        style={[styles.image, { aspectRatio: aspectRatio[gender] }]}
-      />
-      <View style={styles.content}>
-        <Text style={styles.socialSecurityNumber}>{data.personalNumber}</Text>
-        <View style={styles.buttons}>
-          <Button
-            style={styles.button}
-            status="success"
-            size="medium"
-            accessoryRight={CheckIcon}
-            onPress={navigateToChildren}
-          >
-            Fortsätt
-          </Button>
-          <Button
-            size="medium"
-            accessoryRight={CloseOutlineIcon}
-            onPress={startLogout}
-          >
-            Logga ut
-          </Button>
+    <FlingGestureHandler
+      direction={Directions.LEFT}
+      numberOfPointers={1}
+      onHandlerStateChange={navigateToChildren}
+    >
+      <View>
+        <Image
+          source={imageSources[gender]}
+          style={[styles.image, { aspectRatio: aspectRatio[gender] }]}
+        />
+        <View style={styles.content}>
+          <Text style={styles.socialSecurityNumber}>{data.personalNumber}</Text>
+          <View style={styles.buttons}>
+            <Button
+              style={styles.button}
+              status="success"
+              size="medium"
+              accessoryRight={CheckIcon}
+              onPress={navigateToChildren}
+            >
+              Fortsätt
+            </Button>
+            <Button
+              size="medium"
+              accessoryRight={CloseOutlineIcon}
+              onPress={startLogout}
+            >
+              Logga ut
+            </Button>
+          </View>
         </View>
       </View>
-    </>
+    </FlingGestureHandler>
   )
 }
 

--- a/packages/app/components/logout.component.js
+++ b/packages/app/components/logout.component.js
@@ -58,7 +58,7 @@ export const Logout = ({ navigation }) => {
               accessoryRight={CheckIcon}
               onPress={navigateToChildren}
             >
-              Fortsätt
+              Gå tillbaka
             </Button>
             <Button
               size="medium"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,7 @@
     "react-native-calendar-events": "2.2.0",
     "react-native-calendar-strip": "2.2.0",
     "react-native-fix-image": "2.1.0",
-    "react-native-gesture-handler": "1.10.3",
+    "react-native-gesture-handler": "^1.10.3",
     "react-native-markdown-display": "7.0.0-alpha.2",
     "react-native-modal-datetime-picker": "9.2.0",
     "react-native-reanimated": "1.13.2",

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -1518,10 +1518,10 @@
     react-redux "^7.2.2"
     redux "^4.0.5"
 
-"@skolplattformen/embedded-api@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-2.0.2.tgz#45eb35b2d3e3366cf455459bf94081365e04b232"
-  integrity sha512-5nMo2SuF64NX8LGfzJt6AW5w3qW+yO55AN9ITtGbzDRRVckVgKZf4M62gn4HPoH4KatTgdE/RcJwI4z/ETcppg==
+"@skolplattformen/embedded-api@^2.0.4":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-2.1.0.tgz#3204917582bc5cd076d95eee18bc442358a138f3"
+  integrity sha512-+VDEHY654jmwas5Arc1Gz+6qfh5x1xQpJ6H3Kgf69Ay1MZIswTta+6RjOkAti1WNHgrjGY0h1OkFE1o0riop3A==
   dependencies:
     "@types/he" "^1.1.1"
     camelcase-keys "^6.2.2"
@@ -7466,7 +7466,7 @@ react-native-fix-image@2.1.0:
   resolved "https://registry.yarnpkg.com/react-native-fix-image/-/react-native-fix-image-2.1.0.tgz#a4677b91529be926544775faf736df6af8c4743c"
   integrity sha512-qn4xItNSKfwlSkMHgxH9cusUQuk5Lhag9aHqL9ESxnCDUDwqS6rsWuOYt/JlncaKhsCc9cANFomCLlY8+Ffuaw==
 
-react-native-gesture-handler@1.10.3:
+react-native-gesture-handler@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
   integrity sha512-cBGMi1IEsIVMgoox4RvMx7V2r6bNKw0uR1Mu1o7NbuHS6BRSVLq0dP34l2ecnPlC+jpWd3le6Yg1nrdCjby2Mw==


### PR DESCRIPTION
Directions verkar inte fungera i Android, så man kan svepa åt alla håll för att gå tillbaka.
Största nackdelen just nu är att vyn inte täcker hela fönstret, och man måste börja svepa inom vyn för att svepet ska detekteras. Bör gå att lägga till någon vy som täcker 100% av bredden.
Böt också "Fortsätt"-knappen till "Gå tillbaka" då det kändes som att det är lättare att förstå vad det faktiskt innebär

https://user-images.githubusercontent.com/3758043/112230634-78a27480-8c35-11eb-8ce9-1e9e22382287.mov


closes #197 