### PR TITLE
fix: göm bilder i nyhetslistan för mindre enheter

### DIFF
--- a/packages/app/components/newsListItem.component.js
+++ b/packages/app/components/newsListItem.component.js
@@ -1,10 +1,12 @@
 import { useNavigation } from '@react-navigation/native'
 import { DateTime } from 'luxon'
 import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Dimensions, StyleSheet, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import { useChild } from './childContext.component'
 import { Image } from './image.component'
+
+const { width } = Dimensions.get('window')
 
 export const NewsListItem = ({ item }) => {
   const navigation = useNavigation()
@@ -19,7 +21,7 @@ export const NewsListItem = ({ item }) => {
       onPress={() => navigation.navigate('NewsItem', { newsItem: item, child })}
     >
       <View style={styles.card}>
-        <Image src={item.fullImageUrl} style={styles.image} />
+        {width > 320 && <Image src={item.fullImageUrl} style={styles.image} />}
         <View style={styles.text}>
           <View>
             <Text style={styles.title}>{item.header}</Text>


### PR DESCRIPTION
Bilderna i nyhetsflödet tar upp mycket plats på mindre enheter. Den här PR:n gömmer bilderna om bredden på enheten är 320 eller mindre.

Fixes #198 

| iPhone SE | iPhone 11 |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone SE (1st gen) - 2021-03-25 at 13 00 07](https://user-images.githubusercontent.com/1478102/112471324-084a3f00-8d6c-11eb-9f46-c8a9ef3c1a39.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-25 at 13 00 09](https://user-images.githubusercontent.com/1478102/112471316-06807b80-8d6c-11eb-9867-5cf62b6b8c64.png) | 



