### PR TITLE
fix: separera navigation i två olika stackar

### DIFF
--- a/packages/app/components/children.component.js
+++ b/packages/app/components/children.component.js
@@ -13,6 +13,7 @@ import { Dimensions, Image, SafeAreaView, StyleSheet, View } from 'react-native'
 import ActionSheet from 'rn-actionsheet-module'
 import { ChildListItem } from './childListItem.component'
 import { SettingsIcon } from './icon.component'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const { width } = Dimensions.get('window')
 
@@ -27,6 +28,7 @@ export const Children = ({ navigation }) => {
     switch (index) {
       case 0:
         api.logout()
+        AsyncStorage.clear()
         navigation.navigate('Login')
     }
   }

--- a/packages/app/components/login.component.js
+++ b/packages/app/components/login.component.js
@@ -83,7 +83,6 @@ export const Login = ({ navigation }) => {
 
   const loginHandler = async () => {
     showModal(false)
-    navigateToChildren()
   }
 
   useEffect(() => {
@@ -110,11 +109,6 @@ export const Login = ({ navigation }) => {
     } catch (err) {
       setError('Öppna BankID manuellt')
     }
-  }
-
-  /* Navigation actions */
-  const navigateToChildren = () => {
-    navigation.navigate('Children')
   }
 
   const startLogin = async (text) => {

--- a/packages/app/components/navigation.component.js
+++ b/packages/app/components/navigation.component.js
@@ -1,3 +1,4 @@
+import { useApi } from '@skolplattformen/api-hooks'
 import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
@@ -11,16 +12,6 @@ import { NewsItem } from './newsItem.component'
 
 const { Navigator, Screen } = createStackNavigator()
 
-const HomeNavigator = () => (
-  <Navigator headerMode="none">
-    <Screen name="Login" component={Auth} />
-    <Screen name="Children" component={Children} />
-    <Screen name="Child" component={Child} />
-    <Screen name="NewsItem" component={NewsItem} />
-    <Screen name="Absence" component={Absence} />
-  </Navigator>
-)
-
 const linking = {
   prefixes: [schema],
   config: {
@@ -30,10 +21,23 @@ const linking = {
   },
 }
 export const AppNavigator = () => {
+  const { isLoggedIn } = useApi()
+
   return (
     <NavigationContainer linking={linking}>
       <StatusBar />
-      <HomeNavigator />
+      <Navigator headerMode="none">
+        {isLoggedIn ? (
+          <>
+            <Screen name="Children" component={Children} />
+            <Screen name="Child" component={Child} />
+            <Screen name="NewsItem" component={NewsItem} />
+            <Screen name="Absence" component={Absence} />
+          </>
+        ) : (
+          <Screen name="Login" component={Auth} />
+        )}
+      </Navigator>
     </NavigationContainer>
   )
 }


### PR DESCRIPTION
Den här PRn separerar navigationen i två separata "stackar". Detta gör att det inte går att råka navigera tillbaka till inloggningssidan genom att svepa till höger.