### PR TITLE
refactor(app): lägg till designsystem

### DIFF
--- a/packages/app/components/absence.component.tsx
+++ b/packages/app/components/absence.component.tsx
@@ -19,6 +19,7 @@ import React from 'react'
 import { SafeAreaView, StyleSheet, View } from 'react-native'
 import DateTimePickerModal from 'react-native-modal-datetime-picker'
 import * as Yup from 'yup'
+import { Colors, Layout as LayoutStyle, Sizing, Typography } from '../styles'
 import { studentName } from '../utils/peopleHelpers'
 import { useSMS } from '../utils/SMS'
 import { BackIcon } from './icon.component'
@@ -232,17 +233,23 @@ const Absence = () => {
 export default Absence
 
 const styles = StyleSheet.create({
-  safeArea: { backgroundColor: '#fff', flex: 1 },
-  topBar: { backgroundColor: '#fff' },
-  wrap: { flex: 1, padding: 20 },
-  field: { marginBottom: 16 },
-  partOfDay: { flexDirection: 'row', marginBottom: 16 },
-  spacer: { width: 8 },
-  inputHalf: { flex: 1 },
+  safeArea: {
+    ...LayoutStyle.flex.full,
+    backgroundColor: Colors.neutral.white,
+  },
+  topBar: { backgroundColor: Colors.neutral.white },
+  wrap: {
+    ...LayoutStyle.flex.full,
+    padding: Sizing.t5,
+  },
+  field: { marginBottom: Sizing.t4 },
+  partOfDay: { ...LayoutStyle.flex.row, marginBottom: Sizing.t4 },
+  spacer: { width: Sizing.t2 },
+  inputHalf: { ...LayoutStyle.flex.full },
   label: {
+    ...Typography.fontSize.xs,
+    ...Typography.fontWeight.bold,
     color: 'rgb(150,161,184)',
-    fontWeight: '700',
-    fontSize: 12,
-    marginBottom: 4,
+    marginBottom: Sizing.t1,
   },
 })

--- a/packages/app/components/auth.component.tsx
+++ b/packages/app/components/auth.component.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native'
 import { Login } from './login.component'
+import { Colors, Layout as LayoutStyle, Sizing, Typography } from '../styles'
 
 const funArguments = [
   'agila',
@@ -62,21 +63,23 @@ export const Auth = () => {
 }
 
 const styles = StyleSheet.create({
-  keyboardAvoidingView: { flex: 1 },
-  safeArea: { flex: 1, backgroundColor: '#fff' },
+  keyboardAvoidingView: { ...LayoutStyle.flex.full },
+  safeArea: {
+    ...LayoutStyle.flex.full,
+    backgroundColor: Colors.neutral.white,
+  },
   container: {
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 20,
+    ...LayoutStyle.mainAxis.center,
+    ...LayoutStyle.crossAxis.flexEnd,
+    padding: Sizing.t5,
   },
   content: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
+    ...LayoutStyle.center,
+    ...LayoutStyle.flex.full,
   },
   subtitle: {
+    ...Typography.align.center,
     color: '#9CA3AF',
-    marginTop: 4,
-    textAlign: 'center',
+    marginTop: Sizing.t1,
   },
 })

--- a/packages/app/components/child.component.tsx
+++ b/packages/app/components/child.component.tsx
@@ -16,6 +16,7 @@ import {
 import React from 'react'
 import { StyleProp, StyleSheet, TextProps } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { Colors, Layout as LayoutStyle } from '../styles'
 import { studentName } from '../utils/peopleHelpers'
 import { Calendar } from './calendar.component'
 import { ChildProvider } from './childContext.component'
@@ -148,11 +149,11 @@ export const Child = () => {
 
 const styles = StyleSheet.create({
   wrap: {
-    backgroundColor: '#fff',
-    flex: 1,
+    ...LayoutStyle.flex.full,
+    backgroundColor: Colors.neutral.white,
   },
   topBar: {
-    backgroundColor: '#fff',
+    backgroundColor: Colors.neutral.white,
   },
   backdrop: {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/packages/app/components/childListItem.component.tsx
+++ b/packages/app/components/childListItem.component.tsx
@@ -13,6 +13,7 @@ import { DateTime } from 'luxon'
 import moment from 'moment'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
+import { Colors, Layout, Sizing } from '../styles'
 import { studentName } from '../utils/peopleHelpers'
 import {
   CalendarOutlineIcon,
@@ -199,30 +200,30 @@ export const ChildListItem = ({ child, color }: ChildListItemProps) => {
 
 const styles = StyleSheet.create({
   card: {
-    marginBottom: 20,
+    marginBottom: Sizing.t5,
   },
   cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    ...Layout.flex.row,
+    ...Layout.mainAxis.center,
   },
-  cardAvatar: { margin: 20, marginRight: 0 },
-  cardHeaderText: { margin: 20, flex: 1 },
+  cardAvatar: { margin: Sizing.t5, marginRight: 0 },
+  cardHeaderText: { margin: Sizing.t5, flex: 1 },
   itemFooter: {
-    flexDirection: 'row',
-    justifyContent: 'space-evenly',
-    paddingVertical: 8,
+    ...Layout.flex.row,
+    ...Layout.crossAxis.evenly,
+    paddingVertical: Sizing.t2,
     borderRadius: 5,
     margin: 0,
   },
   itemFooterAbsence: {
-    alignItems: 'flex-start',
-    marginTop: 16,
+    ...Layout.mainAxis.flexStart,
+    marginTop: Sizing.t4,
   },
   item: {
     paddingHorizontal: 0,
   },
   loaded: {
-    color: '#000',
+    color: Colors.neutral.black,
   },
   loading: {
     color: '#555',

--- a/packages/app/components/children.component.tsx
+++ b/packages/app/components/children.component.tsx
@@ -12,7 +12,6 @@ import {
 } from '@ui-kitten/components'
 import React from 'react'
 import {
-  Dimensions,
   Image,
   ListRenderItemInfo,
   SafeAreaView,
@@ -20,10 +19,9 @@ import {
   View,
 } from 'react-native'
 import ActionSheet from 'rn-actionsheet-module'
+import { Colors, Layout as LayoutStyle, Sizing, Typography } from '../styles'
 import { ChildListItem } from './childListItem.component'
 import { SettingsIcon } from './icon.component'
-
-const { width } = Dimensions.get('window')
 
 const colors = ['primary', 'success', 'info', 'warning', 'danger']
 const settingsOptions = ['Logga ut', 'Avbryt']
@@ -110,48 +108,43 @@ export const Children = () => {
 
 const styles = StyleSheet.create({
   topContainer: {
-    flex: 1,
-    backgroundColor: '#fff',
+    ...LayoutStyle.flex.full,
+    backgroundColor: Colors.neutral.white,
   },
   loading: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    ...LayoutStyle.center,
+    ...LayoutStyle.flex.full,
   },
   loadingImage: {
-    height: (width / 16) * 9,
-    width: width,
+    ...Sizing.aspectRatio(),
   },
   loadingMessage: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginTop: 8,
+    ...LayoutStyle.mainAxis.center,
+    ...LayoutStyle.flex.row,
+    marginTop: Sizing.t2,
   },
   loadingText: {
-    marginLeft: 20,
+    marginLeft: Sizing.t5,
   },
   childList: {
-    flex: 1,
+    ...LayoutStyle.flex.full,
   },
   childListContainer: {
-    padding: 20,
+    padding: Sizing.t5,
   },
   emptyState: {
-    backgroundColor: '#fff',
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 20,
+    ...LayoutStyle.center,
+    ...LayoutStyle.flex.full,
+    backgroundColor: Colors.neutral.white,
+    paddingHorizontal: Sizing.t5,
   },
   emptyStateDescription: {
+    ...Typography.align.center,
     lineHeight: 21,
-    marginTop: 8,
-    textAlign: 'center',
+    marginTop: Sizing.t2,
   },
   emptyStateImage: {
-    // 80% size and 16:9 aspect ratio
-    height: ((width * 0.8) / 16) * 9,
-    marginTop: 20,
-    width: width * 0.8,
+    ...Sizing.aspectRatio(0.8),
+    marginTop: Sizing.t5,
   },
 })

--- a/packages/app/components/login.component.tsx
+++ b/packages/app/components/login.component.tsx
@@ -10,7 +10,6 @@ import {
 import Personnummer from 'personnummer'
 import React, { useEffect, useState } from 'react'
 import {
-  Dimensions,
   Image,
   Linking,
   Platform,
@@ -28,8 +27,6 @@ import {
   SecureIcon,
   SelectIcon,
 } from './icon.component'
-
-const { width } = Dimensions.get('window')
 
 export const Login = () => {
   const { api } = useApi()

--- a/packages/app/components/login.component.tsx
+++ b/packages/app/components/login.component.tsx
@@ -21,6 +21,7 @@ import {
 import ActionSheet from 'rn-actionsheet-module'
 import { useAsyncStorage } from 'use-async-storage'
 import { schema } from '../app.json'
+import { Colors, Layout, Sizing } from '../styles'
 import {
   CloseOutlineIcon,
   PersonIcon,
@@ -209,21 +210,20 @@ export const Login = () => {
 
 const styles = StyleSheet.create({
   image: {
-    height: ((width * 0.9) / 4) * 3,
-    marginVertical: 16,
-    width: width * 0.9,
+    ...Sizing.aspectRatio(0.9, Sizing.Ratio['4:3']),
+    marginVertical: Sizing.t4,
   },
   loginForm: {
-    justifyContent: 'flex-end',
-    alignItems: 'flex-start',
-    paddingHorizontal: 20,
+    ...Layout.mainAxis.flexStart,
+    ...Layout.crossAxis.flexEnd,
+    paddingHorizontal: Sizing.t5,
   },
   pnrInput: { minHeight: 70 },
   loginButtonGroup: {
     minHeight: 45,
   },
-  loginButton: { flex: 1 },
-  loginButtonText: { color: '#fff' },
+  loginButton: { ...Layout.flex.full },
+  loginButtonText: { color: Colors.neutral.white },
   loginMethodButton: { width: 45 },
   modal: {
     width: '80%',

--- a/packages/app/components/newsListItem.component.tsx
+++ b/packages/app/components/newsListItem.component.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 import React from 'react'
 import { Dimensions, StyleSheet, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
+import { Colors, Layout, Sizing, Typography } from '../styles'
 import { useChild } from './childContext.component'
 import { Image } from './image.component'
 import { RootStackParamList } from './navigation.component'
@@ -57,36 +58,36 @@ export const NewsListItem = ({ item }: NewsListItemProps) => {
 
 const styles = StyleSheet.create({
   card: {
-    flex: 1,
-    flexDirection: 'row',
-    backgroundColor: '#fff',
+    ...Layout.flex.full,
+    ...Layout.flex.row,
+    backgroundColor: Colors.neutral.white,
     borderRadius: 2,
     borderColor: '#f0f0f0',
     borderWidth: 1,
-    padding: 20,
-    marginBottom: 8,
+    padding: Sizing.t5,
+    marginBottom: Sizing.t2,
   },
   text: {
-    flex: 1,
+    ...Layout.flex.full,
   },
   title: {
-    fontSize: 18,
-    fontWeight: '700',
+    ...Typography.fontWeight.bold,
+    ...Typography.fontSize.lg,
     marginBottom: 2,
   },
   subtitle: {
+    ...Typography.fontSize.xs,
     color: '#6B7280',
-    fontSize: 12,
-    marginBottom: 8,
+    marginBottom: Sizing.t2,
   },
   intro: {
+    ...Typography.fontSize.sm,
     color: '#374151',
-    fontSize: 14,
   },
   image: {
     borderRadius: 3,
     width: 80,
     height: 80,
-    marginRight: 16,
+    marginRight: Sizing.t5,
   },
 })

--- a/packages/app/components/notification.component.tsx
+++ b/packages/app/components/notification.component.tsx
@@ -3,6 +3,7 @@ import { Card, Text } from '@ui-kitten/components'
 import { DateTime } from 'luxon'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
+import { Colors, Layout, Sizing, Typography } from '../styles'
 import { ModalWebView } from './modalWebView.component'
 
 interface NotificationProps {
@@ -43,20 +44,19 @@ export const Notification = ({ item }: NotificationProps) => {
 
 const styles = StyleSheet.create({
   card: {
-    flex: 1,
-    backgroundColor: '#fff',
+    ...Layout.flex.full,
+    backgroundColor: Colors.neutral.white,
     borderRadius: 2,
     borderColor: '#f0f0f0',
     borderWidth: 1,
-    marginBottom: 8,
+    marginBottom: Sizing.t2,
   },
   title: {
-    fontSize: 18,
-    fontWeight: '700',
+    ...Typography.header,
     marginBottom: 2,
   },
   subtitle: {
     color: '#6B7280',
-    fontSize: 12,
+    ...Typography.fontSize.xs,
   },
 })

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,6 +48,7 @@
     "react-native-svg": "12.1.0",
     "react-native-svg-transformer": "0.14.3",
     "react-native-tab-view": "2.15.2",
+    "react-native-typography": "^1.4.1",
     "react-native-webview": "11.2.4",
     "rn-actionsheet-module": "1.0.3",
     "use-async-storage": "1.2.0",

--- a/packages/app/styles/colors.ts
+++ b/packages/app/styles/colors.ts
@@ -1,0 +1,5 @@
+type Neutral = 'white' | 'black'
+export const neutral: Record<Neutral, string> = {
+  white: '#ffffff',
+  black: '#000000',
+}

--- a/packages/app/styles/index.ts
+++ b/packages/app/styles/index.ts
@@ -1,0 +1,6 @@
+import * as Colors from './colors'
+import * as Layout from './layout'
+import * as Sizing from './sizing'
+import * as Typography from './typography'
+
+export { Colors, Layout, Sizing, Typography }

--- a/packages/app/styles/layout.ts
+++ b/packages/app/styles/layout.ts
@@ -1,0 +1,39 @@
+import { ViewStyle } from 'react-native'
+
+type MainAxis = 'center' | 'flexStart'
+export const mainAxis: Record<MainAxis, ViewStyle> = {
+  center: {
+    alignItems: 'center',
+  },
+  flexStart: {
+    alignItems: 'flex-start',
+  },
+}
+
+type CrossAxis = 'center' | 'flexEnd' | 'evenly'
+export const crossAxis: Record<CrossAxis, ViewStyle> = {
+  center: {
+    justifyContent: 'center',
+  },
+  evenly: {
+    justifyContent: 'space-evenly',
+  },
+  flexEnd: {
+    justifyContent: 'flex-end',
+  },
+}
+
+export const center: ViewStyle = {
+  ...mainAxis.center,
+  ...crossAxis.center,
+}
+
+type Flex = 'full' | 'row'
+export const flex: Record<Flex, ViewStyle> = {
+  full: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+}

--- a/packages/app/styles/sizing.ts
+++ b/packages/app/styles/sizing.ts
@@ -1,0 +1,51 @@
+import { Dimensions, ImageStyle } from 'react-native'
+
+const { height: screenHeight, width: screenWidth } = Dimensions.get('screen')
+type Screen = 'width' | 'height'
+export const screen: Record<Screen, number> = {
+  width: screenWidth,
+  height: screenHeight,
+}
+
+export enum Ratio {
+  '4:3',
+  '16:9',
+}
+
+export const aspectRatio = (
+  modifier = 1,
+  ratio: Ratio = Ratio['16:9']
+): ImageStyle => {
+  switch (ratio) {
+    case Ratio['16:9']:
+      return {
+        height: ((screen.width * modifier) / 16) * 9,
+        width: screen.width * modifier,
+      }
+    case Ratio['4:3']:
+      return {
+        height: ((screen.width * modifier) / 4) * 3,
+        width: screen.width * modifier,
+      }
+  }
+}
+
+type Layout = 't1' | 't2' | 't3' | 't4' | 't5'
+export const layout: Record<Layout, number> = {
+  t1: 4,
+  t2: 8,
+  t3: 12,
+  t4: 16,
+  t5: 20,
+}
+
+/** 4px */
+export const t1 = layout.t1
+/** 8px */
+export const t2 = layout.t2
+/** 12px */
+export const t3 = layout.t3
+/** 16px */
+export const t4 = layout.t4
+/** 20px */
+export const t5 = layout.t5

--- a/packages/app/styles/typography.ts
+++ b/packages/app/styles/typography.ts
@@ -1,0 +1,43 @@
+import { TextStyle } from 'react-native'
+import { systemWeights } from 'react-native-typography'
+
+type FontSize = 'xs' | 'sm' | 'base' | 'lg'
+export const fontSize: Record<FontSize, TextStyle> = {
+  xs: {
+    fontSize: 12,
+  },
+  sm: {
+    fontSize: 14,
+  },
+  base: {
+    fontSize: 16,
+  },
+  lg: {
+    fontSize: 18,
+  },
+}
+
+type FontWeight = 'regular' | 'semibold' | 'bold'
+export const fontWeight: Record<FontWeight, TextStyle> = {
+  regular: {
+    ...systemWeights.regular,
+  },
+  semibold: {
+    ...systemWeights.semibold,
+  },
+  bold: {
+    ...systemWeights.bold,
+  },
+}
+
+export const header: TextStyle = {
+  ...fontSize.lg,
+  ...fontWeight.bold,
+}
+
+type Align = 'center'
+export const align: Record<Align, TextStyle> = {
+  center: {
+    textAlign: 'center',
+  },
+}

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -7427,6 +7427,11 @@ react-native-tab-view@2.15.2:
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.15.2.tgz#4bc7832d33a119306614efee667509672a7ee64e"
   integrity sha512-2hxLkBnZtEKFDyfvNO5EUywhy3f/EiLOBO8SWqKj4BMBTO0QwnybaPE5MVF00Fhz+VA4+h/iI40Dkrrtq70dGg==
 
+react-native-typography@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-typography/-/react-native-typography-1.4.1.tgz#2d05cb5935a2f7fdb6b43bbde93d60f1324578e3"
+  integrity sha512-dc9Zfs4jUdq4ygx4/KwO6jKTERBu6cRrfPJGntw/pA+D6BMjlWfMNuhZ/69vf4Zpsnt9s4AGe+Z/V1QFYaCXAA==
+
 react-native-webview@11.2.4:
   version "11.2.4"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.2.4.tgz#4615648cea9d928e5d59dc5d8b031167841b8dd6"


### PR DESCRIPTION
Appen har spretig styling i vissa delar, t.ex. margin-värden som bara används på ett ställe. Vi har också styling för färger och typografi som återanvänds på flera ställen som kan samlas i ett designsystem. Den här PR:n lägger till ett system som är inspirerat av [Thoughbots React Native styling](https://github.com/thoughtbot/react-native-typescript-styles-example) och storlekar från Tailwind (som vi använder i `site`). Tanken är att bygga en atomic styling som enkelt kan pusslas ihop till exporterade komponenter när vi ser att något återanvänds.

På sikt tänker jag att detta helt kan ersätta vår användning av `ui-kitten` vilket ger oss större kontroll över hur vi vill att appen ska se ut.

Designsystemet har bara påbörjats och alla filer har inte migrerats till det, men jag tänker att det får bli ett löpande arbete att byta ut och uppgradera.