### PR TITLE
fix: ta bort anteckningar från kalenderevent

### DIFF
--- a/packages/app/components/__tests__/saveToCalendar.test.js
+++ b/packages/app/components/__tests__/saveToCalendar.test.js
@@ -35,7 +35,6 @@ const defaultEvent = {
   startDate: '2021-06-19 13:00',
   endDate: '2021-06-19 14:00',
   location: 'Gubbängsskolan',
-  description: 'Vi går igenom hur Kanye West har presterat denna terminen',
 }
 
 const defaultProps = {
@@ -106,7 +105,6 @@ test('removes any null values from the event', async () => {
     startDate: '2021-06-19T11:00:00.000Z',
     endDate: '2021-06-19T12:00:00.000Z',
     location: 'Gubbängsskolan',
-    notes: 'Vi går igenom hur Kanye West har presterat denna terminen',
   })
 })
 

--- a/packages/app/components/saveToCalendar.component.tsx
+++ b/packages/app/components/saveToCalendar.component.tsx
@@ -40,7 +40,6 @@ export const SaveToCalendar = ({ event }: SaveToCalendarProps) => {
     startDate,
     endDate,
     location,
-    description: notes,
   }: CalendarItem) => {
     const auth = await RNCalendarEvents.requestPermissions()
 
@@ -54,7 +53,6 @@ export const SaveToCalendar = ({ event }: SaveToCalendarProps) => {
             ? new Date(endDate).toISOString()
             : new Date().toISOString(),
           location,
-          notes,
         }
 
         const detailsWithoutEmpty = removeEmptyValues(details)


### PR DESCRIPTION
Den här PRn tar bort `notes` när användaren sparar till kalendern. Jag har ingen bra data på vad `description` (fältet som används för `notes`) i ett kalenderevent kan innehålla från API:et, men enligt #188 kan det förekomma HTML. De flesta använder antagligen inte anteckningar och om de gör det så vill de säkert fylla i det själva.

Fixes #188 