### PR TITLE
chore(site): byt ordning på tidslinje och namn till aktuellt

### DIFF
--- a/packages/site/components/NavLinks.tsx
+++ b/packages/site/components/NavLinks.tsx
@@ -48,7 +48,7 @@ const NavLinks = ({ onClick }: NavLinksProps) => {
         </Link>
       </li>
       <li>
-        <NavLink href="/historia">Media & historia</NavLink>
+        <NavLink href="/aktuellt">Aktuellt</NavLink>
       </li>
       <li>
         <Link to="funktioner" href="/#funktioner">

--- a/packages/site/components/TimelineLatest.tsx
+++ b/packages/site/components/TimelineLatest.tsx
@@ -3,7 +3,7 @@ import { ButtonLinkInternal } from './ButtonLink'
 import Timeline from './Timeline'
 
 const TimelineLatest = () => {
-  const latestMonthsEvents = [events.slice().pop()]
+  const latestMonthsEvents = events.slice(0, 1)
 
   return (
     <section className="max-w-6xl px-5 py-8 mx-auto lg:px-0 lg:py-32 grid grid-cols-1 lg:grid-cols-2 gap-8">
@@ -30,7 +30,7 @@ const TimelineLatest = () => {
           attackeras nu appen från stadens sida. Här är vårt försök till att
           skapa transparens.
         </p>
-        <ButtonLinkInternal href="/historia">
+        <ButtonLinkInternal href="/aktuellt">
           Läs hela historien
         </ButtonLinkInternal>
       </div>

--- a/packages/site/data/timelineEvents.tsx
+++ b/packages/site/data/timelineEvents.tsx
@@ -28,66 +28,141 @@ export const events: TimelineEvent[] = [
   {
     overview: (
       <p>
-        Månaden då Christian Landgren får nog av att försöka sammanställa
-        informationen för sina tre barn på ett översiktligt sätt och begär ut
-        API-dokumentationen från kommunen
+        IT-direktören meddelar att utstörningsåtgärderna nu ska upphöra. Det gör
+        de inte. Mars är månaden då vi släpper sju releaser som svar på stadens
+        sju sabotage av appen. Samtidigt hittar våra kodare ytterligare
+        allvarliga säkerhetsproblem i stadens it-system och rapporterar dessa
+        till kommunen.
       </p>
     ),
-    date: '2020-11-01',
+    date: '2021-03-01',
     importantDates: [
+      fixEvent('2021-03-29'),
       {
-        date: '2020-11-27',
+        date: '2021-03-29',
         description:
-          'Begäran om dokumentation av API (skickat till Kontaktcenter Stockholm)',
+          'Öppna skolplattformen anmäler ytterligare ett säkerhetsproblem i stadens IT-system',
+      },
+      {
+        date: '2021-03-27',
+        description:
+          'Öppna Skolplattformen tar sig till globala Hacker News förstasida',
+        link: 'https://news.ycombinator.com/item?id=26597293',
+      },
+      sabotageEvent('2021-03-26'),
+      fixEvent('2021-03-26'),
+      sabotageEvent('2021-03-25'),
+      fixEvent('2021-03-25'),
+      sabotageEvent('2021-03-24'),
+      fixEvent('2021-03-24'),
+      {
+        date: '2021-03-23',
+        description:
+          'Öppna Skolplattformen överklagar avslag av begäran av API-dokumentation till Kammarrätten ',
+      },
+      sabotageEvent('2021-03-22'),
+      fixEvent('2021-03-19'),
+      sabotageEvent('2021-03-19'),
+      fixEvent('2021-03-18'),
+      sabotageEvent('2021-03-18'),
+      fixEvent('2021-03-17'),
+      {
+        date: '2021-03-11',
+        description: 'Möte nr 2 med kommunen',
+      },
+      {
+        date: '2021-03-06',
+        description:
+          'Kommunen skickar mail med följande formulering: “Jag vill berätta för dig att idag kommer vårt arbete som haft negativ påverkan på er app att upphöra.”',
+      },
+      {
+        date: '2021-03-04',
+        description:
+          'Kommunen fattar beslut om att avslå begäran om dokumentation av API',
+      },
+      {
+        date: '2021-03-01',
+        description:
+          'Tjänstedesignern Sigrun Tallungs skriver en sammanfattning på LinkedIn: Men hur gick det ens till?',
+        link:
+          'https://www.linkedin.com/pulse/men-hur-gick-det-ens-till-rapport-fr%25C3%25A5n-insidan-sigrun-tallungs/?trackingId=uF%2FBCFt5QMeshcx7oWOypA%3D%3D',
       },
     ],
-  },
-  {
-    overview: (
-      <p>
-        Christian Landgren får nog av att vänta på API-dokumentationen från
-        kommunen och börjar programmera. Han får snart sällskap av några av
-        Sveriges topprankade kodare (också föräldrar. Utvecklare är nämligen det
-        vanligaste jobbet bland män i Stockholm. Brist på kompetens föreligger
-        inte).
-      </p>
-    ),
-    date: '2020-12-01',
-    importantDates: [
-      {
-        date: '2020-12-06',
-        description:
-          'Den första sårbarheten i kommunens system hittas och rapporteras till staden via ombud',
-      },
-      {
-        date: '2020-12-03',
-        description:
-          'Avslag på begäran om dokumentation med hänvisning till sekretess men utan lagrum',
-      },
-    ],
-  },
-  {
-    overview: (
-      <p>
-        Månaden då appen utvecklas. Utan dokumenterat API får utvecklarna nöja
-        sig med att reverse engineera baserat på sin egen upplevelse och sin
-        egen data, och förbättringar baseras på hur andra föräldrar använder
-        skolplattformen. Källkoden publiceras på{' '}
-        <Link.External href="https://github.com/kolplattformen">
-          GitHub
-        </Link.External>{' '}
-        för full transparens och för att bjuda in till samarbete.
-      </p>
-    ),
-    date: '2021-01-01',
-    importantDates: [],
     media: [
       {
-        date: '2021-01-18',
+        date: '2021-03-31',
         description:
-          'Forskaren: Så skulle det bästa IT-systemet för skolan se ut (Skolvärlden)',
+          'Maktkampen om Skolplattformen fortsätter: ”Välriktat sabotage” (Ny Teknik)',
         link:
-          'https://www.skolvarlden.se/artiklar/forskaren-sa-skulle-det-basta-it-systemet-skolan-se-ut',
+          'https://www.nyteknik.se/digitalisering/maktkampen-om-skolplattformen-fortsatter-valriktat-sabotage-7012339',
+      },
+      {
+        date: '2021-03-30',
+        description:
+          'Säkerhetsbrister upptäckta i Stockholm stads IT-system (SVT Nyheter Sthlm)',
+        link:
+          'https://www.svt.se/nyheter/lokalt/stockholm/sakerhetsbrister-upptackta-i-stockholms-stads-it-system',
+      },
+      {
+        date: '2021-03-30',
+        description:
+          'Stor säkerhetslucka i Stockholms stads it-system – sårbart för attacker (NyTeknik)',
+        link:
+          'https://www.nyteknik.se/digitalisering/stor-sakerhetslucka-i-stockholms-stads-it-system-sarbart-for-attacker-7012123',
+      },
+      {
+        date: '2021-03-29',
+        description:
+          'De utmanar Stockholms stads kritiserade Skolplattformen: ”Stockholm stad stökar bara till” (Expressen/DI TV)',
+        link:
+          'https://www.expressen.se/tv/ditv/ekonomistudion/de-utmanar-skolplattformen/',
+      },
+      {
+        date: '2021-03-29',
+        description:
+          'Stockholms stad sätter krokben för föräldrarnas skolplattform (DI Digital)',
+        link:
+          'https://digital.di.se/artikel/stockholms-stad-satter-krokben-for-foraldrarnas-skolplattform',
+      },
+      {
+        date: '2021-03-29',
+        description:
+          'Strid mellan föräldrar och staden om skolplattforms-app (Mitti)',
+        link:
+          'https://www.mitti.se/nyheter/strid-mellan-foraldrar-och-staden-om-skolplattforms-app/repucx!1Pdq1EzU1bVp5ns0Fuykjg/',
+      },
+      {
+        date: '2021-03-24',
+        description:
+          'Dåliga it-lösningar får värre konsekvenser än bara missnöjda användare (Bohusläningen)',
+        link:
+          'https://www.bohuslaningen.se/%C3%A5sikt/ledare/d%C3%A5liga-it-l%C3%B6sningar-f%C3%A5r-v%C3%A4rre-konsekvenser-%C3%A4n-bara-missn%C3%B6jda-anv%C3%A4ndare-1.43510223',
+      },
+      {
+        date: '2021-03-23',
+        description:
+          'Kodsnack 410 – Öppna skolplattformen, med Johan Öbrink (podd, Kodsnack)',
+        link:
+          'https://techworld.idg.se/2.2524/1.748569/kodsnack-410--oppna-skolplattformen-med-johan-obrink',
+      },
+      {
+        date: '2021-03-05',
+        description:
+          'Öppna skolplattformen med Johan Öbrink och Erik Hellman (podd, Kompilator)',
+        link: 'https://kompilator.se/041/',
+      },
+      {
+        date: '2021-03-04',
+        description:
+          '”Öppna skolplattformen är medborgaraktivism för bättre offentlig digitalisering” (debattartikel, NyTeknik)',
+        link:
+          'https://www.nyteknik.se/opinion/oppna-skolplattformen-ar-medborgaraktivism-for-battre-offentlig-digitalisering-7010976',
+      },
+      {
+        date: '2021-03-01',
+        description: 'Stockholms stad stoppar Öppna Skolplattformen (Feber.se)',
+        link:
+          'https://feber.se/samhalle/stockholms-stad-stoppar-oppna-skolplattformen/421986/',
       },
     ],
   },
@@ -256,141 +331,66 @@ export const events: TimelineEvent[] = [
   {
     overview: (
       <p>
-        IT-direktören meddelar att utstörningsåtgärderna nu ska upphöra. Det gör
-        de inte. Mars är månaden då vi släpper sju releaser som svar på stadens
-        sju sabotage av appen. Samtidigt hittar våra kodare ytterligare
-        allvarliga säkerhetsproblem i stadens it-system och rapporterar dessa
-        till kommunen.
+        Månaden då appen utvecklas. Utan dokumenterat API får utvecklarna nöja
+        sig med att reverse engineera baserat på sin egen upplevelse och sin
+        egen data, och förbättringar baseras på hur andra föräldrar använder
+        skolplattformen. Källkoden publiceras på{' '}
+        <Link.External href="https://github.com/kolplattformen">
+          GitHub
+        </Link.External>{' '}
+        för full transparens och för att bjuda in till samarbete.
       </p>
     ),
-    date: '2021-03-01',
-    importantDates: [
-      fixEvent('2021-03-29'),
-      {
-        date: '2021-03-29',
-        description:
-          'Öppna skolplattformen anmäler ytterligare ett säkerhetsproblem i stadens IT-system',
-      },
-      {
-        date: '2021-03-27',
-        description:
-          'Öppna Skolplattformen tar sig till globala Hacker News förstasida',
-        link: 'https://news.ycombinator.com/item?id=26597293',
-      },
-      sabotageEvent('2021-03-26'),
-      fixEvent('2021-03-26'),
-      sabotageEvent('2021-03-25'),
-      fixEvent('2021-03-25'),
-      sabotageEvent('2021-03-24'),
-      fixEvent('2021-03-24'),
-      {
-        date: '2021-03-23',
-        description:
-          'Öppna Skolplattformen överklagar avslag av begäran av API-dokumentation till Kammarrätten ',
-      },
-      sabotageEvent('2021-03-22'),
-      fixEvent('2021-03-19'),
-      sabotageEvent('2021-03-19'),
-      fixEvent('2021-03-18'),
-      sabotageEvent('2021-03-18'),
-      fixEvent('2021-03-17'),
-      {
-        date: '2021-03-11',
-        description: 'Möte nr 2 med kommunen',
-      },
-      {
-        date: '2021-03-06',
-        description:
-          'Kommunen skickar mail med följande formulering: “Jag vill berätta för dig att idag kommer vårt arbete som haft negativ påverkan på er app att upphöra.”',
-      },
-      {
-        date: '2021-03-04',
-        description:
-          'Kommunen fattar beslut om att avslå begäran om dokumentation av API',
-      },
-      {
-        date: '2021-03-01',
-        description:
-          'Tjänstedesignern Sigrun Tallungs skriver en sammanfattning på LinkedIn: Men hur gick det ens till?',
-        link:
-          'https://www.linkedin.com/pulse/men-hur-gick-det-ens-till-rapport-fr%25C3%25A5n-insidan-sigrun-tallungs/?trackingId=uF%2FBCFt5QMeshcx7oWOypA%3D%3D',
-      },
-    ],
+    date: '2021-01-01',
+    importantDates: [],
     media: [
       {
-        date: '2021-03-31',
+        date: '2021-01-18',
         description:
-          'Maktkampen om Skolplattformen fortsätter: ”Välriktat sabotage” (Ny Teknik)',
+          'Forskaren: Så skulle det bästa IT-systemet för skolan se ut (Skolvärlden)',
         link:
-          'https://www.nyteknik.se/digitalisering/maktkampen-om-skolplattformen-fortsatter-valriktat-sabotage-7012339',
+          'https://www.skolvarlden.se/artiklar/forskaren-sa-skulle-det-basta-it-systemet-skolan-se-ut',
+      },
+    ],
+  },
+  {
+    overview: (
+      <p>
+        Christian Landgren får nog av att vänta på API-dokumentationen från
+        kommunen och börjar programmera. Han får snart sällskap av några av
+        Sveriges topprankade kodare (också föräldrar. Utvecklare är nämligen det
+        vanligaste jobbet bland män i Stockholm. Brist på kompetens föreligger
+        inte).
+      </p>
+    ),
+    date: '2020-12-01',
+    importantDates: [
+      {
+        date: '2020-12-06',
+        description:
+          'Den första sårbarheten i kommunens system hittas och rapporteras till staden via ombud',
       },
       {
-        date: '2021-03-30',
+        date: '2020-12-03',
         description:
-          'Säkerhetsbrister upptäckta i Stockholm stads IT-system (SVT Nyheter Sthlm)',
-        link:
-          'https://www.svt.se/nyheter/lokalt/stockholm/sakerhetsbrister-upptackta-i-stockholms-stads-it-system',
+          'Avslag på begäran om dokumentation med hänvisning till sekretess men utan lagrum',
       },
+    ],
+  },
+  {
+    overview: (
+      <p>
+        Månaden då Christian Landgren får nog av att försöka sammanställa
+        informationen för sina tre barn på ett översiktligt sätt och begär ut
+        API-dokumentationen från kommunen
+      </p>
+    ),
+    date: '2020-11-01',
+    importantDates: [
       {
-        date: '2021-03-30',
+        date: '2020-11-27',
         description:
-          'Stor säkerhetslucka i Stockholms stads it-system – sårbart för attacker (NyTeknik)',
-        link:
-          'https://www.nyteknik.se/digitalisering/stor-sakerhetslucka-i-stockholms-stads-it-system-sarbart-for-attacker-7012123',
-      },
-      {
-        date: '2021-03-29',
-        description:
-          'De utmanar Stockholms stads kritiserade Skolplattformen: ”Stockholm stad stökar bara till” (Expressen/DI TV)',
-        link:
-          'https://www.expressen.se/tv/ditv/ekonomistudion/de-utmanar-skolplattformen/',
-      },
-      {
-        date: '2021-03-29',
-        description:
-          'Stockholms stad sätter krokben för föräldrarnas skolplattform (DI Digital)',
-        link:
-          'https://digital.di.se/artikel/stockholms-stad-satter-krokben-for-foraldrarnas-skolplattform',
-      },
-      {
-        date: '2021-03-29',
-        description:
-          'Strid mellan föräldrar och staden om skolplattforms-app (Mitti)',
-        link:
-          'https://www.mitti.se/nyheter/strid-mellan-foraldrar-och-staden-om-skolplattforms-app/repucx!1Pdq1EzU1bVp5ns0Fuykjg/',
-      },
-      {
-        date: '2021-03-24',
-        description:
-          'Dåliga it-lösningar får värre konsekvenser än bara missnöjda användare (Bohusläningen)',
-        link:
-          'https://www.bohuslaningen.se/%C3%A5sikt/ledare/d%C3%A5liga-it-l%C3%B6sningar-f%C3%A5r-v%C3%A4rre-konsekvenser-%C3%A4n-bara-missn%C3%B6jda-anv%C3%A4ndare-1.43510223',
-      },
-      {
-        date: '2021-03-23',
-        description:
-          'Kodsnack 410 – Öppna skolplattformen, med Johan Öbrink (podd, Kodsnack)',
-        link:
-          'https://techworld.idg.se/2.2524/1.748569/kodsnack-410--oppna-skolplattformen-med-johan-obrink',
-      },
-      {
-        date: '2021-03-05',
-        description:
-          'Öppna skolplattformen med Johan Öbrink och Erik Hellman (podd, Kompilator)',
-        link: 'https://kompilator.se/041/',
-      },
-      {
-        date: '2021-03-04',
-        description:
-          '”Öppna skolplattformen är medborgaraktivism för bättre offentlig digitalisering” (debattartikel, NyTeknik)',
-        link:
-          'https://www.nyteknik.se/opinion/oppna-skolplattformen-ar-medborgaraktivism-for-battre-offentlig-digitalisering-7010976',
-      },
-      {
-        date: '2021-03-01',
-        description: 'Stockholms stad stoppar Öppna Skolplattformen (Feber.se)',
-        link:
-          'https://feber.se/samhalle/stockholms-stad-stoppar-oppna-skolplattformen/421986/',
+          'Begäran om dokumentation av API (skickat till Kontaktcenter Stockholm)',
       },
     ],
   },

--- a/packages/site/next.config.js
+++ b/packages/site/next.config.js
@@ -2,10 +2,17 @@ const withImages = require('next-images')
 
 module.exports = {
   ...withImages(),
+  async rewrites() {
+    return [
+      {
+        source: '/historia',
+        destination: '/aktuellt',
+      },
+    ]
+  },
   i18n: {
     localeDetection: false,
     locales: ['sv', 'en'],
     defaultLocale: 'sv',
   },
 }
-

--- a/packages/site/pages/aktuellt.tsx
+++ b/packages/site/pages/aktuellt.tsx
@@ -2,11 +2,11 @@ import Timeline from '../components/Timeline'
 import { H1 } from '../components/Typography'
 import { events } from '../data/timelineEvents'
 
-const HistoryPage = () => {
+const CurrentEventsPage = () => {
   return (
     <section className="mx-5 max-w-2xl md:mx-auto">
       <div className="my-8 md:my-20">
-        <H1>Media & historia</H1>
+        <H1>Aktuellt</H1>
         <div className="mt-12">
           <Timeline events={events} />
         </div>
@@ -15,4 +15,4 @@ const HistoryPage = () => {
   )
 }
 
-export default HistoryPage
+export default CurrentEventsPage


### PR DESCRIPTION
Den här PR:n byter namn för tidslinjen från "Media & Historia" till "Aktuellt". Den är också ordningen till senast först.