### PR TITLE
chore: använd redirect istället för rewrite

### DIFF
--- a/packages/site/next.config.js
+++ b/packages/site/next.config.js
@@ -2,11 +2,12 @@ const withImages = require('next-images')
 
 module.exports = {
   ...withImages(),
-  async rewrites() {
+  async redirects() {
     return [
       {
         source: '/historia',
         destination: '/aktuellt',
+        permanent: true,
       },
     ]
   },


### PR DESCRIPTION
Använd `redirects` istället för `rewrites` för historia -> aktuellt vilket ger en snyggare omskrivning av länkarna till gamla.