### PR TITLE
fix: fel i datumhantering

### DIFF
--- a/packages/app/components/childListItem.component.tsx
+++ b/packages/app/components/childListItem.component.tsx
@@ -49,14 +49,16 @@ export const ChildListItem = ({ child, color }: ChildListItemProps) => {
     moment().add(7, 'days').toISOString()
   )
 
-  const notificationsThisWeek = notifications.filter((n) =>
-    moment(n.dateCreated).isSame('week')
-  )
+  const notificationsThisWeek = notifications.filter(({ dateCreated }) => {
+    dateCreated ? moment(dateCreated).isSame(moment(), 'week') : false
+  })
 
   const scheduleAndCalendarThisWeek = [
     ...(calendar ?? []),
     ...(schedule ?? []),
-  ].filter((a) => moment(a.startDate).isSame('week'))
+  ].filter(({ startDate }) =>
+    startDate ? moment(startDate).isSame(moment(), 'week') : false
+  )
 
   const getClassName = () => {
     // hack: we can find the class name (ex. 8C) from the classmates. let's pick the first one and select theirs class

--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -535,9 +535,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 0bd88dccda1f83b7a01f01706f3728c8b36a5b30
+  FBReactNativeSpec: bc9813353956ed2de2f370de75d9c1123e81f425
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
@@ -545,7 +545,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   hermes-engine: 7d97ba46a1e29bacf3e3c61ecb2804a5ddd02d4f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
@@ -589,6 +589,6 @@ SPEC CHECKSUMS:
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 55e3aa728a80834bbc3ec778624aaa8d3cd962e0
+PODFILE CHECKSUM: 150d11b9d14e4a3ff5a788d22b641a6bfbd16381
 
 COCOAPODS: 1.10.1

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "@react-navigation/native": "5.9.3",
     "@react-navigation/stack": "5.14.3",
     "@skolplattformen/api-hooks": "2.0.0",
-    "@skolplattformen/embedded-api": "^2.1.7",
+    "@skolplattformen/embedded-api": "^3.0.0",
     "@ui-kitten/components": "5.0.0",
     "@ui-kitten/eva-icons": "5.0.0",
     "buffer": "6.0.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "@react-navigation/native": "5.9.3",
     "@react-navigation/stack": "5.14.3",
     "@skolplattformen/api-hooks": "2.0.0",
-    "@skolplattformen/embedded-api": "^3.0.0",
+    "@skolplattformen/embedded-api": "^3.0.1",
     "@ui-kitten/components": "5.0.0",
     "@ui-kitten/eva-icons": "5.0.0",
     "buffer": "6.0.3",

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -1456,10 +1456,10 @@
     react-redux "^7.2.2"
     redux "^4.0.5"
 
-"@skolplattformen/embedded-api@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-3.0.0.tgz#1972c445b81028e45164d06b4ac65cb5bdfb9e77"
-  integrity sha512-i15lRtB2ZGhJYh75dSLnBv6fcIyba1SJYcThEZdo032kSGH5/PxWvQdA1S7q7E6nXx1LmysU8rXpoKANXmxetw==
+"@skolplattformen/embedded-api@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-3.0.1.tgz#51ab2debc764c6b5886661e4c2797cf1c82edbf2"
+  integrity sha512-T3y/3dgiC5vnKjAMth/hXt2K+KW7EaigyJEUykwr4hlB1Tz5H8aICMA0RR/5fiGkbbwYvrPh4ZhPS5cqOjPWxQ==
   dependencies:
     "@types/he" "^1.1.1"
     camelcase-keys "^6.2.2"

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -1456,10 +1456,10 @@
     react-redux "^7.2.2"
     redux "^4.0.5"
 
-"@skolplattformen/embedded-api@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-2.1.7.tgz#a9a8fef51c3765f1c3dc0ae2dc14af4ec0f3a520"
-  integrity sha512-uKo4zal5pylqh4PefKogbBGGXYTr3Rpd2VNjnPrbx54PexoIcduQGw0lEtGcp3XHQXiw1fyEglWVgT9djD6www==
+"@skolplattformen/embedded-api@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@skolplattformen/embedded-api/-/embedded-api-3.0.0.tgz#1972c445b81028e45164d06b4ac65cb5bdfb9e77"
+  integrity sha512-i15lRtB2ZGhJYh75dSLnBv6fcIyba1SJYcThEZdo032kSGH5/PxWvQdA1S7q7E6nXx1LmysU8rXpoKANXmxetw==
   dependencies:
     "@types/he" "^1.1.1"
     camelcase-keys "^6.2.2"


### PR DESCRIPTION
Den här PR:n uppdaterar `embedded-api` till `v3.0.1` som innehåller fixar för datumhantering. Den fixar också en varning från `moment` som kom från att vi inte skicka något datum att jämföra med till `isSame`:

```js
// Vi hade
moment(date).isSame('week')

// Det ska vara
moment(date).isSame(moment(), 'week')
```