### PR TITLE
feat: 🎸 Datum i kalendern

### DIFF
--- a/packages/app/components/calendar.component.tsx
+++ b/packages/app/components/calendar.component.tsx
@@ -31,7 +31,9 @@ export const Calendar = () => {
         <ListItem
           disabled={true}
           title={`${item.title}`}
-          description={`${moment(item.startDate).fromNow()}`}
+          description={`${moment(item.startDate).format(
+            'YYYY-MM-DD'
+          )} (${moment(item.startDate).fromNow()})`}
           accessoryLeft={CalendarOutlineIcon}
           accessoryRight={() => <SaveToCalendar event={item} />}
         />


### PR DESCRIPTION
Lade till datum i kalendervyn. Att bara se att skolan stänger 15:45 om en månad kändes som för lite information. Merga om det känns vettigt.

Före: "om en månad"
Efter: "2021-04-30 (om en månad)"