### PR TITLE
fix: 🐛 Settings menu was not updated on language change

### DIFF
--- a/packages/app/components/children.component.tsx
+++ b/packages/app/components/children.component.tsx
@@ -20,12 +20,13 @@ import { ChildListItem } from './childListItem.component'
 import { SettingsIcon } from './icon.component'
 
 const colors = ['primary', 'success', 'info', 'warning', 'danger']
-const settingsOptions = [
-  translate('general.logout'),
-  translate('general.abort'),
-]
 
 export const Children = () => {
+  const settingsOptions = [
+    translate('general.logout'),
+    translate('general.abort'),
+  ]
+  
   const { api } = useApi()
   const { data: childList, status } = useChildList()
   const insets = useSafeAreaInsets()

--- a/packages/app/components/children.component.tsx
+++ b/packages/app/components/children.component.tsx
@@ -26,7 +26,7 @@ export const Children = () => {
     translate('general.logout'),
     translate('general.abort'),
   ]
-  
+
   const { api } = useApi()
   const { data: childList, status } = useChildList()
   const insets = useSafeAreaInsets()


### PR DESCRIPTION
On the "settings" panel the translations did not update if you had logged out and changed language, this is because the settingsOptions was outside the component so it did not update.
## This did not update:
![image](https://user-images.githubusercontent.com/54435884/115131689-5f090880-9ffa-11eb-896c-42729532a341.png)
