### PR TITLE
Fix save button placement in language on Android

### DIFF
--- a/packages/app/components/setLanguage.component.tsx
+++ b/packages/app/components/setLanguage.component.tsx
@@ -122,6 +122,7 @@ const styles = StyleSheet.create({
     ...LayoutStyle.center,
     ...LayoutStyle.flex.full,
     margin: Sizing.t5,
+    paddingBottom: Sizing.t5,
   },
   buttonGroup: {
     minHeight: 45,


### PR DESCRIPTION
On Android the save button was under the navigation bar in language selection