### PR TITLE
chore(a11y): move shape that interferes button

### DIFF
--- a/packages/site/components/Banner.tsx
+++ b/packages/site/components/Banner.tsx
@@ -38,7 +38,7 @@ const Banner = () => {
                 <img
                   src={shape3}
                   alt=""
-                  className="absolute -bottom-2 left-8 motion-safe:animate-pulse"
+                  className="absolute left-48 top-18 motion-safe:animate-pulse"
                 />
                 <img
                   src={shape4}


### PR DESCRIPTION

Shape was over button so you couldn't interact with button where the shape was. 

![sc1](https://user-images.githubusercontent.com/54435884/115700080-9cf18e00-a366-11eb-8b58-e8838e736b25.png)
