### PR TITLE
chore(app): fix type for modal onLoad

### DIFF
--- a/packages/app/components/modalWebView.component.tsx
+++ b/packages/app/components/modalWebView.component.tsx
@@ -7,10 +7,10 @@ import {
   StyleSheet,
   TouchableOpacity,
   View,
-  SyntheticEvent,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { WebView } from 'react-native-webview'
+import { WebViewNavigationEvent } from 'react-native-webview/lib/WebViewTypes'
 import { BackIcon, ExternalLinkIcon } from './icon.component'
 
 interface ModalWebViewProps {
@@ -73,7 +73,7 @@ export const ModalWebView = ({
             source={{ uri: url, headers }}
             sharedCookiesEnabled={sharedCookiesEnabled}
             thirdPartyCookiesEnabled={sharedCookiesEnabled}
-            onLoad={(event: SyntheticEvent) => {
+            onLoad={(event: WebViewNavigationEvent) => {
               setTitle(event.nativeEvent.title)
             }}
           />


### PR DESCRIPTION
The modal was using `SyntheticEvent`, which does not exist in `react-native`. This imports the correct type from the `react-native-webview` instead.