### PR TITLE
Add postinstall script to fix FBReactNativeSpec hash change

### DIFF
--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -542,7 +542,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 0b41cf9e0b74ffa97ededb3d0210da5b4710474c
+  FBReactNativeSpec: 5e508b58518de4f083a88fb46f48d79c62fdc988
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,8 @@
     "test:watch": "jest --watch",
     "typecheck": "tsc --watch",
     "i18n": "sync-i18n --files '**/translations/*.json' --primary en --languages ar de pl so sv --space 2",
-    "check-i18n": "npm run i18n -- --check"
+    "check-i18n": "npm run i18n -- --check",
+    "postinstall": "./postinstall-fix-rn-064-bugs.sh"
   },
   "dependencies": {
     "@eva-design/eva": "2.0.0",

--- a/packages/app/postinstall-fix-rn-064-bugs.sh
+++ b/packages/app/postinstall-fix-rn-064-bugs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+OS=`uname`
+
+echo "Fixing RN 0.64.0 bugs:"
+cd node_modules/react-native/scripts
+echo "- unset PREFIX in find-node.sh"
+if [ `cat find-node.sh | grep 'unset PREFIX' | wc -l` -lt 1 ]
+then
+  cp find-node.sh tmp
+  head -n 1 tmp >find-node.sh
+  echo "unset PREFIX" >>find-node.sh
+  tail -n +2 tmp >>find-node.sh
+  rm tmp
+fi
+
+if [ "$OS" = 'Darwin' ]
+then
+  # for MacOS; cannot install Pods on Win/Linux
+  echo "- switch to relative paths in react_native_pods.rb "
+  sed -i '' -e "s/File[.]join[(]__dir__, \"[.][.]\"[)]/\"..\/..\/node_modules\/react-native\"/" react_native_pods.rb
+  sed -i '' -e "s/#{File[.]join[(]__dir__, \"generate-specs.sh\"[)]}/..\/..\/node_modules\/react-native\/scripts\/generate-specs.sh/" react_native_pods.rb
+  sed -i '' -e "s/spec[.]prepare_command = \"#/spec.prepare_command = \"cd ..\/.. \&\& #/" react_native_pods.rb
+fi
+
+cd - >/dev/null


### PR DESCRIPTION
The hash in Podfile.lock for FBReactNativeSpec kept changing on different developer machines. That is because the file the hash is based on contains absolute paths.
See https://github.com/facebook/react-native/issues/31193 for more info.

This commit adds a postinstall script that fixes that bug.