### PR TITLE
fix: 🐛 Ord som inte är översatta hämtas från svenska

### DIFF
--- a/packages/app/services/languageService.ts
+++ b/packages/app/services/languageService.ts
@@ -47,7 +47,7 @@ export const LanguageService = {
   setLanguageCode: ({ langCode }: { langCode?: string }) => {
     if (langCode && allString[langCode]) {
       languageCode = langCode
-      Strings = allString[langCode]
+      Strings = { ...allString.sv, ...allString[langCode] }
     } else {
       const dataKeys = Object.keys(allString)
       languageCode = dataKeys[0]


### PR DESCRIPTION
Fallback till svenska på ord som inte finns i en översättning.