### PR TITLE
fix: article and article list styling

### DIFF
--- a/packages/app/components/newsItem.component.tsx
+++ b/packages/app/components/newsItem.component.tsx
@@ -145,6 +145,7 @@ const themedStyles = StyleService.create({
     width: '100%',
     minHeight: 300,
     marginTop: Sizing.t4,
+    borderRadius: 15,
   },
   title: {
     ...Typography.fontWeight.bold,

--- a/packages/app/components/newsList.component.tsx
+++ b/packages/app/components/newsList.component.tsx
@@ -1,18 +1,25 @@
-import React, { useState, useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useNews } from '@skolplattformen/api-hooks'
-import { List, Input } from '@ui-kitten/components'
-import { StyleSheet, TouchableWithoutFeedback } from 'react-native'
-import { Sizing } from '../styles'
-import { useChild } from './childContext.component'
-import { NewsListItem } from './newsListItem.component'
-import { translate } from '../utils/translation'
 import {
-  useNewsListSearchResults,
+  Divider,
+  Input,
+  List,
+  StyleService,
+  useStyleSheet,
+} from '@ui-kitten/components'
+import { TouchableWithoutFeedback } from 'react-native'
+import { Sizing } from '../styles'
+import {
   renderSearchResultPreview,
+  useNewsListSearchResults,
 } from '../utils/search'
-import { SearchIcon, CloseOutlineIcon } from './icon.component'
+import { translate } from '../utils/translation'
+import { useChild } from './childContext.component'
+import { CloseOutlineIcon, SearchIcon } from './icon.component'
+import { NewsListItem } from './newsListItem.component'
 
 export const NewsList = () => {
+  const styles = useStyleSheet(themedStyles)
   const child = useChild()
   const { data } = useNews(child)
 
@@ -67,15 +74,17 @@ export const NewsList = () => {
       keyboardDismissMode="on-drag"
       data={data}
       ListHeaderComponent={header}
+      ItemSeparatorComponent={Divider}
       renderItem={({ item }) => <NewsListItem key={item.id} item={item} />}
     />
   )
 }
 
-const styles = StyleSheet.create({
+const themedStyles = StyleService.create({
   container: {
     height: '100%',
     width: '100%',
+    backgroundColor: 'background-basic-color-1',
   },
   contentContainer: {
     padding: Sizing.t3,

--- a/packages/app/components/newsList.component.tsx
+++ b/packages/app/components/newsList.component.tsx
@@ -87,6 +87,6 @@ const themedStyles = StyleService.create({
     backgroundColor: 'background-basic-color-1',
   },
   contentContainer: {
-    padding: Sizing.t3,
+    paddingHorizontal: Sizing.t5,
   },
 })

--- a/packages/app/components/newsListItem.component.tsx
+++ b/packages/app/components/newsListItem.component.tsx
@@ -66,15 +66,7 @@ const themedStyles = StyleService.create({
   card: {
     ...Layout.flex.full,
     ...Layout.flex.row,
-
-    borderRadius: 2,
-
-    borderWidth: 1,
-    padding: Sizing.t5,
-    marginBottom: Sizing.t2,
-
-    backgroundColor: 'background-basic-color-1',
-    borderColor: 'border-basic-color-3',
+    paddingVertical: Sizing.t3,
   },
   text: {
     ...Layout.flex.full,
@@ -95,9 +87,9 @@ const themedStyles = StyleService.create({
     color: 'text-basic-color',
   },
   image: {
-    borderRadius: 3,
-    width: 80,
-    height: 80,
+    borderRadius: 15,
+    width: 70,
+    height: 70,
     marginRight: Sizing.t5,
   },
 })


### PR DESCRIPTION
Ny styling för artikellistning samt la till border-radius på bilden på artikellistan.

Light Mode                |  Dark Mode
:-------------------------:|:-------------------------:
<img width="267" alt="CleanShot 2021-05-17 at 22 09 43@2x" src="https://user-images.githubusercontent.com/4541038/118550352-ddbda680-b75c-11eb-997a-3413301b6c26.png"> |  <img width="267" alt="CleanShot 2021-05-17 at 22 11 28@2x" src="https://user-images.githubusercontent.com/4541038/118550369-e2825a80-b75c-11eb-8e9d-71d9f01c6f19.png">
<img width="267" alt="CleanShot 2021-05-17 at 22 09 51@2x" src="https://user-images.githubusercontent.com/4541038/118550359-df876a00-b75c-11eb-9307-75f3d59c9578.png"> | <img width="267" alt="CleanShot 2021-05-17 at 22 11 32@2x" src="https://user-images.githubusercontent.com/4541038/118550384-e4e4b480-b75c-11eb-875f-54645512cb3a.png">