### PR TITLE
fix: notification list styling

### DIFF
--- a/packages/app/components/notification.component.tsx
+++ b/packages/app/components/notification.component.tsx
@@ -1,7 +1,7 @@
 import { Notification as NotificationType } from '@skolplattformen/embedded-api'
-import { Card, StyleService, Text, useStyleSheet } from '@ui-kitten/components'
+import { StyleService, Text, useStyleSheet } from '@ui-kitten/components'
 import React from 'react'
-import { View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import { Layout, Sizing, Typography } from '../styles'
 import { ModalWebView } from './modalWebView.component'
 import moment from 'moment'
@@ -26,11 +26,9 @@ export const Notification = ({ item }: NotificationProps) => {
 
   return (
     <>
-      <Card
-        style={styles.card}
-        onPress={open}
-        header={(headerProps) => (
-          <View {...headerProps}>
+      <TouchableOpacity onPress={open}>
+        <View style={styles.card}>
+          <View>
             <Text style={styles.title}>{item.sender}</Text>
             <Text style={styles.subtitle}>
               {item.category ? item.category : ''}
@@ -38,10 +36,9 @@ export const Notification = ({ item }: NotificationProps) => {
               {displayDate ? displayDate : ''}
             </Text>
           </View>
-        )}
-      >
-        <Text>{item.message}</Text>
-      </Card>
+          <Text>{item.message}</Text>
+        </View>
+      </TouchableOpacity>
       {isOpen && (
         <ModalWebView
           url={item.url}
@@ -56,13 +53,7 @@ export const Notification = ({ item }: NotificationProps) => {
 const themedStyles = StyleService.create({
   card: {
     ...Layout.flex.full,
-    borderRadius: 2,
-
-    borderWidth: 1,
-    marginBottom: Sizing.t2,
-
-    backgroundColor: 'background-basic-color-1',
-    borderColor: 'border-basic-color-3',
+    paddingVertical: Sizing.t3,
   },
   title: {
     ...Typography.header,
@@ -71,5 +62,6 @@ const themedStyles = StyleService.create({
   subtitle: {
     ...Typography.fontSize.xs,
     color: 'text-hint-color',
+    marginBottom: Sizing.t2,
   },
 })

--- a/packages/app/components/notificationsList.component.tsx
+++ b/packages/app/components/notificationsList.component.tsx
@@ -34,6 +34,6 @@ const themedStyles = StyleService.create({
     backgroundColor: 'background-basic-color-1',
   },
   contentContainer: {
-    paddingHorizontal: Sizing.t3,
+    paddingHorizontal: Sizing.t5,
   },
 })

--- a/packages/app/components/notificationsList.component.tsx
+++ b/packages/app/components/notificationsList.component.tsx
@@ -1,12 +1,17 @@
 import { useNotifications } from '@skolplattformen/api-hooks'
-import { List } from '@ui-kitten/components'
+import {
+  Divider,
+  List,
+  StyleService,
+  useStyleSheet,
+} from '@ui-kitten/components'
 import React from 'react'
-import { StyleSheet } from 'react-native'
 import { Sizing } from '../styles'
 import { useChild } from './childContext.component'
 import { Notification } from './notification.component'
 
 export const NotificationsList = () => {
+  const styles = useStyleSheet(themedStyles)
   const child = useChild()
   const { data } = useNotifications(child)
   return (
@@ -14,6 +19,7 @@ export const NotificationsList = () => {
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
       data={data}
+      ItemSeparatorComponent={Divider}
       renderItem={(info) => (
         <Notification key={info.item.id} item={info.item} />
       )}
@@ -21,12 +27,13 @@ export const NotificationsList = () => {
   )
 }
 
-const styles = StyleSheet.create({
+const themedStyles = StyleService.create({
   container: {
     height: '100%',
     width: '100%',
+    backgroundColor: 'background-basic-color-1',
   },
   contentContainer: {
-    padding: Sizing.t3,
+    paddingHorizontal: Sizing.t3,
   },
 })


### PR DESCRIPTION
Lite ny design på notis-sidan. Tog bort kortlayouten så lite mer fokus på innehållet.

Light Mode                |  Dark Mode
:-------------------------:|:-------------------------:
<img width="534" alt="CleanShot 2021-05-17 at 22 23 59@2x" src="https://user-images.githubusercontent.com/4541038/118552203-e9aa6800-b75e-11eb-9b1e-c6291c2075d4.png"> | <img width="534" alt="CleanShot 2021-05-17 at 22 25 14@2x" src="https://user-images.githubusercontent.com/4541038/118552196-e7e0a480-b75e-11eb-8712-0f1f44961580.png">

