### PR TITLE
fix: 🐛 Fixes long navigation names in tab bar

### DIFF
--- a/packages/app/components/tabBarLabel.component.tsx
+++ b/packages/app/components/tabBarLabel.component.tsx
@@ -15,6 +15,8 @@ export const TabBarLabel = ({ label, focused }: TabBarLabelProps) => {
       <Text
         style={[styles.label, focused ? styles.focused : null]}
         maxFontSizeMultiplier={2}
+        numberOfLines={1}
+        ellipsizeMode="tail"
       >
         {label}
       </Text>


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 12 - 2021-09-14 at 08 00 07](https://user-images.githubusercontent.com/722315/133203680-51443568-02d8-45da-976b-5d63bd02e7a2.png)
![Simulator Screen Shot - iPhone 12 - 2021-09-14 at 08 03 30](https://user-images.githubusercontent.com/722315/133203687-c0f0fe80-8a9e-473d-92dd-474a6174235d.png)
