### PR TITLE
fix: fontSize on tabBarLabel decreased

### DIFF
--- a/packages/app/components/tabBarLabel.component.tsx
+++ b/packages/app/components/tabBarLabel.component.tsx
@@ -25,7 +25,7 @@ export const TabBarLabel = ({ label, focused }: TabBarLabelProps) => {
 
 const themedStyles = StyleService.create({
   label: {
-    fontWeight: '600',
+    fontWeight: '500',
     color: 'color-tab-default',
     ...fontSize.xxs,
   },

--- a/packages/app/components/tabBarLabel.component.tsx
+++ b/packages/app/components/tabBarLabel.component.tsx
@@ -1,6 +1,7 @@
 import { StyleService, Text, useStyleSheet } from '@ui-kitten/components'
 import React from 'react'
 import { View } from 'react-native'
+import { fontSize } from '../styles/typography'
 
 export type TabBarLabelProps = {
   label: string
@@ -25,8 +26,8 @@ export const TabBarLabel = ({ label, focused }: TabBarLabelProps) => {
 const themedStyles = StyleService.create({
   label: {
     fontWeight: '600',
-    fontSize: 12,
     color: 'color-tab-default',
+    ...fontSize.xxs,
   },
   focused: {
     color: 'color-tab-focused',


### PR DESCRIPTION
Before:
<img width="393" alt="CleanShot 2021-09-14 at 09 24 02@2x" src="https://user-images.githubusercontent.com/4541038/133213712-d4838a05-87f9-4283-9e28-7190fea16659.png">

After:
<img width="393" alt="CleanShot 2021-09-14 at 09 24 14@2x" src="https://user-images.githubusercontent.com/4541038/133213731-509e87c3-f99e-4d4d-8789-8a60d55777c4.png">
