### PR TITLE
fix: 🐛 Välja språk på Android var trasigt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ secrets.yaml
 requests
 xcshareddata
 xcuserdata
+/.vs

--- a/packages/app/components/setLanguage.component.tsx
+++ b/packages/app/components/setLanguage.component.tsx
@@ -8,8 +8,8 @@ import {
   useTheme,
 } from '@ui-kitten/components'
 import React, { useState } from 'react'
-import { View } from 'react-native'
-import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler'
+import { View, TouchableOpacity } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
 import RNRestart from 'react-native-restart'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { NativeStackNavigationOptions } from 'react-native-screens/native-stack'


### PR DESCRIPTION
En bugg i react-native-gesture-handler gjorde att det inte gick att ändra språk på android.