### PR TITLE
fix: 🐛 Småfixar i schemat

### DIFF
--- a/packages/app/components/week.component.tsx
+++ b/packages/app/components/week.component.tsx
@@ -63,12 +63,11 @@ const LessonList = ({ lessons, header, lunch }: LessonListProps) => {
               <Text
                 style={styles.lessonDescription}
                 maxFontSizeMultiplier={1}
-              >{`${timeStart.slice(0, 5)}-${timeEnd.slice(
-                0,
-                5
-              )} (${location})`}</Text>
+              >{`${timeStart.slice(0, 5)}-${timeEnd.slice(0, 5)} ${
+                location === '' ? '' : '(' + location + ')'
+              } `}</Text>
               <Text style={styles.lessonDescription} maxFontSizeMultiplier={1}>
-                {code === 'Lunch' ? lunch?.description : teacher}
+                {code?.toUpperCase() === 'LUNCH' ? lunch?.description : teacher}
               </Text>
             </View>
           )}


### PR DESCRIPTION
* Skriver inte ut tomma parenteser om det inte finns något klassrum/location för en lektion
* Matsedel skrivs ut även om koden är i versaler (eller annat case)