### PR TITLE
test: 💍 Remove warnings about timers not beeing mocked

### DIFF
--- a/libs/hooks/src/useCalendar.test.js
+++ b/libs/hooks/src/useCalendar.test.js
@@ -191,8 +191,6 @@ describe('useCalendar(child)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -221,8 +219,6 @@ describe('useCalendar(child)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useChildList.test.js
+++ b/libs/hooks/src/useChildList.test.js
@@ -223,8 +223,6 @@ describe('useChildList()', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual(echildrenCache)
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -263,8 +261,6 @@ describe('useChildList()', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual(echildrenCache)
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useClassmates.test.js
+++ b/libs/hooks/src/useClassmates.test.js
@@ -176,8 +176,6 @@ describe('useClassmates(child)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -206,8 +204,6 @@ describe('useClassmates(child)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useEtjanstChildren.test.js
+++ b/libs/hooks/src/useEtjanstChildren.test.js
@@ -174,8 +174,6 @@ describe('useEtjanstChildren()', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -204,8 +202,6 @@ describe('useEtjanstChildren()', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useMenu.test.js
+++ b/libs/hooks/src/useMenu.test.js
@@ -172,8 +172,6 @@ describe('useMenu(child)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -201,8 +199,6 @@ describe('useMenu(child)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useNews.test.js
+++ b/libs/hooks/src/useNews.test.js
@@ -172,8 +172,6 @@ describe('useNews(child)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -201,8 +199,6 @@ describe('useNews(child)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useNewsDetails.test.js
+++ b/libs/hooks/src/useNewsDetails.test.js
@@ -192,8 +192,6 @@ describe('useNewsDetails(child, newsItem)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual({ ...cached })
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -222,8 +220,6 @@ describe('useNewsDetails(child, newsItem)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual({ ...cached })
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useNotifications.test.js
+++ b/libs/hooks/src/useNotifications.test.js
@@ -176,8 +176,6 @@ describe('useNotifications(child)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -206,8 +204,6 @@ describe('useNotifications(child)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useSchedule.test.js
+++ b/libs/hooks/src/useSchedule.test.js
@@ -192,8 +192,6 @@ describe('useSchedule(child, from, to)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -222,8 +220,6 @@ describe('useSchedule(child, from, to)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useSkola24Children.test.js
+++ b/libs/hooks/src/useSkola24Children.test.js
@@ -178,8 +178,6 @@ describe('useSkola24Children()', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ personGuid: '2' }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -208,8 +206,6 @@ describe('useSkola24Children()', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ personGuid: '2' }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useTimetable.test.js
+++ b/libs/hooks/src/useTimetable.test.js
@@ -191,8 +191,6 @@ describe('useTimetable(child, week, year, lang)', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -221,8 +219,6 @@ describe('useTimetable(child, week, year, lang)', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual([{ id: 2 }])
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()

--- a/libs/hooks/src/useUser.test.js
+++ b/libs/hooks/src/useUser.test.js
@@ -162,8 +162,6 @@ describe('useUser()', () => {
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual({ id: 2 })
 
-      jest.advanceTimersToNextTimer()
-
       await waitForNextUpdate()
       await waitForNextUpdate()
       await waitForNextUpdate()
@@ -191,8 +189,6 @@ describe('useUser()', () => {
       expect(result.current.error).toEqual(error)
       expect(result.current.status).toEqual('loading')
       expect(result.current.data).toEqual({ id: 2 })
-
-      jest.advanceTimersToNextTimer()
 
       await waitForNextUpdate()
       await waitForNextUpdate()


### PR DESCRIPTION
The jest.advanceTimersToNextTimer() is not needed by the tests, they pass without it.
The reason the warnings was not seen before was because we used an older version
of jest (26) before. Now with NX we use 27.