### PR TITLE
fix: 🐛 Fixar krasch när ett språks locale inte finns i moment

### DIFF
--- a/apps/skolplattformen-sthlm/components/week.component.tsx
+++ b/apps/skolplattformen-sthlm/components/week.component.tsx
@@ -104,7 +104,7 @@ export const Day = ({ weekDay, lunch, lessons }: DayProps) => {
 }
 
 export const Week = ({ child }: WeekProps) => {
-  moment.locale(LanguageService.getLanguageCode())
+  moment.locale(LanguageService.getLocale())
   const days = moment.weekdaysShort().slice(1, 6)
   const currentDayIndex = Math.min(moment().isoWeekday() - 1, 5)
   const [selectedIndex, setSelectedIndex] = useState(currentDayIndex)

--- a/apps/skolplattformen-sthlm/services/languageService.ts
+++ b/apps/skolplattformen-sthlm/services/languageService.ts
@@ -16,6 +16,7 @@ import 'moment/locale/ru'
 import 'moment/locale/sv'
 import 'moment/locale/zh-cn'
 import { I18nManager } from 'react-native'
+import { languages } from '../utils/translation'
 
 const changeListeners: Record<string, any> = {}
 
@@ -23,6 +24,7 @@ let allString: Record<string, any> = {}
 
 let Strings: Record<string, any> = {}
 let languageCode: string
+let momentLocale: string
 
 const rtlList: { [key: string]: boolean } = {
   en: false,
@@ -40,17 +42,15 @@ export const isRTL = (langCode: string) => {
   return rtlList[langCode]
 }
 
-const getCorrespondingMomentLocale = (langCode?: string): string => {
-  if (langCode === 'la') return 'sv'
-  if (langCode === 'so') return 'sv'
-  if (langCode === 'nb_NO') return 'nb'
-  if (langCode === 'zh_Hant' || langCode === 'zh_Hans') return 'zh-cn'
-  return langCode!
+const getCorrespondingMomentLocale = (languageCode?: string): string => {
+  const lang = languages.find(({ langCode }) => langCode === languageCode)
+  return lang?.locale || 'sv'
 }
 
 export const LanguageService = {
   get: () => Strings,
   getLanguageCode: () => languageCode,
+  getLocale: () => momentLocale,
   setAllData: ({ data }: { data: Record<string, any> }) => {
     allString = data
   },
@@ -61,11 +61,12 @@ export const LanguageService = {
       i18n.locale = langCode
       I18nManager.forceRTL(isRTL(langCode))
     }
-    moment.locale(getCorrespondingMomentLocale(langCode))
+    moment.locale(momentLocale)
   },
   setLanguageCode: ({ langCode }: { langCode?: string }) => {
     if (langCode && allString[langCode]) {
       languageCode = langCode
+      momentLocale = getCorrespondingMomentLocale(langCode)
       Strings = merge(allString.sv, allString[langCode])
     } else {
       const dataKeys = Object.keys(allString)

--- a/apps/skolplattformen-sthlm/utils/translation.ts
+++ b/apps/skolplattformen-sthlm/utils/translation.ts
@@ -4,6 +4,7 @@ interface Language {
   langCode: string
   languageName: string
   languageLocalName: string
+  locale: string
   active: boolean
 }
 
@@ -12,36 +13,42 @@ export const languages: Language[] = [
     langCode: 'sv',
     languageName: 'Swedish',
     languageLocalName: 'Svenska',
+    locale: 'sv',
     active: true,
   },
   {
     langCode: 'ar',
     languageName: 'Arabic',
     languageLocalName: 'اَلْعَرَبِيَّةُ',
+    locale: 'ar',
     active: true,
   },
   {
     langCode: 'zh_Hant',
     languageName: 'Chinese (traditional)',
     languageLocalName: '中國傳統的',
+    locale: 'zh-cn',
     active: true,
   },
   {
     langCode: 'zh_Hans',
     languageName: 'Chinese (simplified)',
     languageLocalName: '简体中文',
+    locale: 'zh-cn',
     active: true,
   },
   {
     langCode: 'nl',
     languageName: 'Dutch',
     languageLocalName: 'Nederlands',
+    locale: 'nl',
     active: true,
   },
   {
     langCode: 'en',
     languageName: 'English',
     languageLocalName: 'English',
+    locale: 'en',
     active: true,
   },
 
@@ -49,6 +56,7 @@ export const languages: Language[] = [
     langCode: 'de',
     languageName: 'German',
     languageLocalName: 'Deutsch',
+    locale: 'de',
     active: true,
   },
 
@@ -56,66 +64,77 @@ export const languages: Language[] = [
     langCode: 'fi',
     languageName: 'Finnish',
     languageLocalName: 'Suomi',
+    locale: 'fi',
     active: true,
   },
   {
     langCode: 'fr',
     languageName: 'French',
     languageLocalName: 'Français',
+    locale: 'fr',
     active: true,
   },
   {
     langCode: 'it',
     languageName: 'Italian',
     languageLocalName: 'Italiano',
+    locale: 'it',
     active: true,
   },
   {
     langCode: 'ja',
     languageName: 'Japanese',
     languageLocalName: '日本語',
+    locale: 'ja',
     active: true,
   },
   {
     langCode: 'la',
     languageName: 'Latin',
     languageLocalName: 'Latina',
+    locale: 'sv',
     active: true,
   },
   {
     langCode: 'nb_NO',
     languageName: 'Norwegian Bokmål',
     languageLocalName: 'Norsk bokmål',
+    locale: 'nb',
     active: true,
   },
   {
     langCode: 'pl',
     languageName: 'Polish',
     languageLocalName: 'Polski',
+    locale: 'pl',
     active: true,
   },
   {
     langCode: 'pt',
     languageName: 'Portuguese',
     languageLocalName: 'Português',
+    locale: 'pt',
     active: true,
   },
   {
     langCode: 'ru',
     languageName: 'Russian',
     languageLocalName: 'русский',
+    locale: 'ru',
     active: false,
   },
   {
     langCode: 'so',
     languageName: 'Somali',
     languageLocalName: 'af-Soomaali',
+    locale: 'sv',
     active: true,
   },
   {
     langCode: 'es',
     languageName: 'Spanish',
     languageLocalName: 'Español',
+    locale: 'es',
     active: true,
   },
 ]


### PR DESCRIPTION
När locale i moment heter annorlunda än landskoden så används rätt namn, annars används svenska