### PR TITLE
Fix: Styles, pricing & contact email

### DIFF
--- a/apps/website/components/FunFacts.tsx
+++ b/apps/website/components/FunFacts.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import CountUp from 'react-countup'
 import VisibilitySensor from 'react-visibility-sensor'
+import { price } from './Pricing'
 
 const FUNFACTS_DATA = [
   {
@@ -12,7 +13,7 @@ const FUNFACTS_DATA = [
     title: 'år att utveckla',
   },
   {
-    count: 11,
+    count: price,
     title: 'kronor kostar vår app :)',
   },
   {

--- a/apps/website/components/Pricing.tsx
+++ b/apps/website/components/Pricing.tsx
@@ -3,7 +3,7 @@ import DownloadButtons from './DownloadButtons'
 import Icon from './Icon'
 import SectionTitle from './SectionTitle'
 
-const price = 12
+export const price = 11
 
 const baseFeatures = [
   {

--- a/apps/website/components/QA.tsx
+++ b/apps/website/components/QA.tsx
@@ -317,7 +317,7 @@ const QA = () => {
         <h3>Kontakta oss</h3>
         <p>
           Tveka inte att kontakta oss. Skicka ett mail till{' '}
-          <a href="mailto:info@skolplattformen.org">dev@skolplattformen.org</a>.
+          <a href="mailto:info@skolplattformen.org">info@skolplattformen.org</a>.
         </p>
       </div>
     </div>

--- a/apps/website/components/QA.tsx
+++ b/apps/website/components/QA.tsx
@@ -1,5 +1,7 @@
 import Link from './Link'
 
+import { price } from './Pricing'
+
 const QA = () => {
   return (
     <div className="header">
@@ -249,7 +251,7 @@ const QA = () => {
           de?
         </h3>
         <p>
-          Appen kostar 12 kronor. Intäkten registreras i aktiebolaget Not Free
+          Appen kostar {price} kronor. Intäkten registreras i aktiebolaget Not Free
           Beer som ägs av tre av utvecklarna och går till att täcka kostnader
           för inköp. Det täcker inte på långa vägar den tid vi lagt ner. Med en
           låg engångskostnad ökar vi chansen att vi orkar syssla med underhåll

--- a/apps/website/tailwind.config.js
+++ b/apps/website/tailwind.config.js
@@ -35,6 +35,9 @@ module.exports = {
             h3: {
               color: theme('colors.white'),
             },
+            h4: {
+              color: theme('colors.white'),
+            },
             a: {
               color: theme('colors.indigo.500'),
             }


### PR DESCRIPTION
**What's the problem(s)?**

<img width="538" alt="Screen Shot 2021-12-02 at 11 44 17" src="https://user-images.githubusercontent.com/200250/144411870-917f1bdb-4922-46ac-a4d3-57920f1c15fa.png">

<img width="520" alt="Screen Shot 2021-12-02 at 11 44 39" src="https://user-images.githubusercontent.com/200250/144411932-187e0d4b-ecfb-40f3-99fc-d827b04447c7.png">

- Missing style for h4 in dark mode.
- Inconsistent pricing; 11 or 12 kronor.
- Incorrect anchor for contact email.

**What's changed?**

- Use `price` constant where we output the current app price.
- Update the contact email anchor.
- Add missing style for h4 in dark mode.

**How can this be verified?**

- Tested locally.