### PR TITLE
fix: 🐛 Ingen text syns i dark mode när inga barn hittas

### DIFF
--- a/apps/skolplattformen-app/components/children.component.tsx
+++ b/apps/skolplattformen-app/components/children.component.tsx
@@ -196,7 +196,6 @@ const themedStyles = StyleService.create({
   emptyState: {
     ...LayoutStyle.center,
     ...LayoutStyle.flex.full,
-    backgroundColor: Colors.neutral.white,
     paddingHorizontal: Sizing.t5,
   },
   emptyStateDescription: {


### PR DESCRIPTION
✅ Closes: #571

Vit text på vit bakgrund gjorde att texten när man loggar in men inte har barn i systemet inte syntes.