### PR TITLE
fix: 🐛 Week starts on monday regardless of selected locale

### DIFF
--- a/apps/skolplattformen-app/components/week.component.tsx
+++ b/apps/skolplattformen-app/components/week.component.tsx
@@ -107,7 +107,13 @@ export const Day = ({ weekDay, lunch, lessons }: DayProps) => {
 }
 
 export const Week = ({ child }: WeekProps) => {
-  moment.locale(LanguageService.getLocale())
+  const locale = LanguageService.getLocale();
+  moment.updateLocale(locale, {
+    week: {
+      dow : 1, // Monday is the first day of the week.
+    }
+  })
+  moment.locale(locale)
   const days = moment.weekdaysShort().slice(1, 6)
   const displayDate = getMeaningfulStartingDate(moment())
 

--- a/apps/skolplattformen-app/components/week.component.tsx
+++ b/apps/skolplattformen-app/components/week.component.tsx
@@ -107,11 +107,11 @@ export const Day = ({ weekDay, lunch, lessons }: DayProps) => {
 }
 
 export const Week = ({ child }: WeekProps) => {
-  const locale = LanguageService.getLocale();
+  const locale = LanguageService.getLocale()
   moment.updateLocale(locale, {
     week: {
-      dow : 1, // Monday is the first day of the week.
-    }
+      dow: 1, // Monday is the first day of the week.
+    },
   })
   moment.locale(locale)
   const days = moment.weekdaysShort().slice(1, 6)


### PR DESCRIPTION
Dates were wrong in Timetable in some languages. This forces the week to always start at Monday (since skolplattformen's week start on Monday)