### PR TITLE
fix: 🐛 Change broken links caused by name change of repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,234 +232,234 @@
 
 * 🐛 Readded keystore ([47c2ca3](https://github.com/kolplattformen/skolplattformen/commit/47c2ca30dcd780437e4f71af317da1c89258ad3d))
 
-## [2.3.1](https://github.com/kolplattformen/skolplattformen-app/compare/v2.3.0...v2.3.1) (2021-11-30)
+## [2.3.1](https://github.com/kolplattformen/skolplattformen/compare/v2.3.0...v2.3.1) (2021-11-30)
 
 
 ### Bug Fixes
 
-* 🐛 Show subject name on Hjärntorget timetable ([b3df527](https://github.com/kolplattformen/skolplattformen-app/commit/b3df527d44904b7838bcb0a9aaef69c276c9c5b7))
+* 🐛 Show subject name on Hjärntorget timetable ([b3df527](https://github.com/kolplattformen/skolplattformen/commit/b3df527d44904b7838bcb0a9aaef69c276c9c5b7))
 
-# [2.3.0](https://github.com/kolplattformen/skolplattformen-app/compare/v2.2.1...v2.3.0) (2021-11-30)
+# [2.3.0](https://github.com/kolplattformen/skolplattformen/compare/v2.2.1...v2.3.0) (2021-11-30)
 
 
 ### Bug Fixes
 
-* 🐛 added dist to ignore ([1230825](https://github.com/kolplattformen/skolplattformen-app/commit/1230825571462a69d00b24f8bae0d6d82f0f5784))
-* 🐛 Added projects to nx ([c88b25a](https://github.com/kolplattformen/skolplattformen-app/commit/c88b25aa102549d8a59fd9e7e0b6af293620378b))
-* 🐛 error loading SKOLA24_CHILDREN SAML ([508b079](https://github.com/kolplattformen/skolplattformen-app/commit/508b0792a10eeac065dd798182f3f4dcf20a27ca))
-* 🐛 Fix failing tests ([8d9cfe2](https://github.com/kolplattformen/skolplattformen-app/commit/8d9cfe2de4ebc2b21584d2cbf930e83857b24263))
-* 🐛 Fixes inheritance from [@skolplattformen-api](https://github.com/skolplattformen-api) ([ba45cfd](https://github.com/kolplattformen/skolplattformen-app/commit/ba45cfd79685fc61b2477f5a3aa9416ba11a1200))
-* 🐛 Fixes issue with package.json in hjarntorget ([e2e1ff8](https://github.com/kolplattformen/skolplattformen-app/commit/e2e1ff82787f967b8c1e8845363291732cae59be))
-* 🐛 Fixes lint errors ([e19c8a7](https://github.com/kolplattformen/skolplattformen-app/commit/e19c8a7747153bbc204efd6cef42b3929cf376d0))
-* 🐛 Fixes news title, lowered font size on header ([7df15d3](https://github.com/kolplattformen/skolplattformen-app/commit/7df15d36b12a82484e903ecb39e38795013ce72c))
-* 🐛 Fixes tests, added esModuleInterop true to tsconfig ([6383795](https://github.com/kolplattformen/skolplattformen-app/commit/63837955a33e3e913b6c88a72ae3c37d95d6b321))
-* 🐛 Fixes TS config + lint etc ([4663269](https://github.com/kolplattformen/skolplattformen-app/commit/46632691bf506199e3e51696e1e26a8c53c42e37))
-* 🐛 Fixes TSconfig for all projects ([24c1624](https://github.com/kolplattformen/skolplattformen-app/commit/24c162419b4768564052fcab662c9aa81d46e8f3))
-* 🐛 Fixes tsconfig in api-hjarntorget ([b641486](https://github.com/kolplattformen/skolplattformen-app/commit/b641486768323baf60a0100b838689cb7a6bee77))
-* 🐛 merge ([d26fd62](https://github.com/kolplattformen/skolplattformen-app/commit/d26fd62e5c7640148f6ba3ef65db1ea3aa6fb274))
-* 🐛 merge conflict ([cafe6ec](https://github.com/kolplattformen/skolplattformen-app/commit/cafe6ec990087dffe828f03be7c9b003709e2197))
-* 🐛 Merge with master ([9d21341](https://github.com/kolplattformen/skolplattformen-app/commit/9d213413bee88a126134557f654bbb7edab4ad46))
-* 🐛 Readded mock, ts config to api ([82e0c6f](https://github.com/kolplattformen/skolplattformen-app/commit/82e0c6f961301c9241cf2ecacb657dbf53326f4f))
-* 🐛 Removed auth-test ([06c29d7](https://github.com/kolplattformen/skolplattformen-app/commit/06c29d75da5e6b503b98c949bf32f78027ee7548))
-* 🐛 removed dist prior to ignore, more lint errors fix ([78f7577](https://github.com/kolplattformen/skolplattformen-app/commit/78f757783f7c3215eae7cdbbb3a33dd5063a1d2a))
-* 🐛 Week component height and cap text ([9874dda](https://github.com/kolplattformen/skolplattformen-app/commit/9874dda30eefca652685419668374e1b460ffc51))
-* auth issues ([ae369c2](https://github.com/kolplattformen/skolplattformen-app/commit/ae369c204c2b6dccdb84c85fd2c6f10dd76bdc8e))
-* fetch typings ([97e131d](https://github.com/kolplattformen/skolplattformen-app/commit/97e131d30d1c021ecf88aafc98820cdaec70fa67))
+* 🐛 added dist to ignore ([1230825](https://github.com/kolplattformen/skolplattformen/commit/1230825571462a69d00b24f8bae0d6d82f0f5784))
+* 🐛 Added projects to nx ([c88b25a](https://github.com/kolplattformen/skolplattformen/commit/c88b25aa102549d8a59fd9e7e0b6af293620378b))
+* 🐛 error loading SKOLA24_CHILDREN SAML ([508b079](https://github.com/kolplattformen/skolplattformen/commit/508b0792a10eeac065dd798182f3f4dcf20a27ca))
+* 🐛 Fix failing tests ([8d9cfe2](https://github.com/kolplattformen/skolplattformen/commit/8d9cfe2de4ebc2b21584d2cbf930e83857b24263))
+* 🐛 Fixes inheritance from [@skolplattformen-api](https://github.com/skolplattformen-api) ([ba45cfd](https://github.com/kolplattformen/skolplattformen/commit/ba45cfd79685fc61b2477f5a3aa9416ba11a1200))
+* 🐛 Fixes issue with package.json in hjarntorget ([e2e1ff8](https://github.com/kolplattformen/skolplattformen/commit/e2e1ff82787f967b8c1e8845363291732cae59be))
+* 🐛 Fixes lint errors ([e19c8a7](https://github.com/kolplattformen/skolplattformen/commit/e19c8a7747153bbc204efd6cef42b3929cf376d0))
+* 🐛 Fixes news title, lowered font size on header ([7df15d3](https://github.com/kolplattformen/skolplattformen/commit/7df15d36b12a82484e903ecb39e38795013ce72c))
+* 🐛 Fixes tests, added esModuleInterop true to tsconfig ([6383795](https://github.com/kolplattformen/skolplattformen/commit/63837955a33e3e913b6c88a72ae3c37d95d6b321))
+* 🐛 Fixes TS config + lint etc ([4663269](https://github.com/kolplattformen/skolplattformen/commit/46632691bf506199e3e51696e1e26a8c53c42e37))
+* 🐛 Fixes TSconfig for all projects ([24c1624](https://github.com/kolplattformen/skolplattformen/commit/24c162419b4768564052fcab662c9aa81d46e8f3))
+* 🐛 Fixes tsconfig in api-hjarntorget ([b641486](https://github.com/kolplattformen/skolplattformen/commit/b641486768323baf60a0100b838689cb7a6bee77))
+* 🐛 merge ([d26fd62](https://github.com/kolplattformen/skolplattformen/commit/d26fd62e5c7640148f6ba3ef65db1ea3aa6fb274))
+* 🐛 merge conflict ([cafe6ec](https://github.com/kolplattformen/skolplattformen/commit/cafe6ec990087dffe828f03be7c9b003709e2197))
+* 🐛 Merge with master ([9d21341](https://github.com/kolplattformen/skolplattformen/commit/9d213413bee88a126134557f654bbb7edab4ad46))
+* 🐛 Readded mock, ts config to api ([82e0c6f](https://github.com/kolplattformen/skolplattformen/commit/82e0c6f961301c9241cf2ecacb657dbf53326f4f))
+* 🐛 Removed auth-test ([06c29d7](https://github.com/kolplattformen/skolplattformen/commit/06c29d75da5e6b503b98c949bf32f78027ee7548))
+* 🐛 removed dist prior to ignore, more lint errors fix ([78f7577](https://github.com/kolplattformen/skolplattformen/commit/78f757783f7c3215eae7cdbbb3a33dd5063a1d2a))
+* 🐛 Week component height and cap text ([9874dda](https://github.com/kolplattformen/skolplattformen/commit/9874dda30eefca652685419668374e1b460ffc51))
+* auth issues ([ae369c2](https://github.com/kolplattformen/skolplattformen/commit/ae369c204c2b6dccdb84c85fd2c6f10dd76bdc8e))
+* fetch typings ([97e131d](https://github.com/kolplattformen/skolplattformen/commit/97e131d30d1c021ecf88aafc98820cdaec70fa67))
 
 
 ### Features
 
-* 🎸 Added food menu to features ([bec62fa](https://github.com/kolplattformen/skolplattformen-app/commit/bec62fa21b9503927b44ad956314a888fa6923e1))
-* 🎸 Feature toggle context ([ce05682](https://github.com/kolplattformen/skolplattformen-app/commit/ce056821a1b1d562e4c36d7ff30dfcb5e3ad3aeb))
-* 🎸 fixes ts issues ([3f62016](https://github.com/kolplattformen/skolplattformen-app/commit/3f62016d6add2f5f234d6125c002b4d4603a5783))
-* 🎸 Merged with main, also added api to nx ([4f1f66f](https://github.com/kolplattformen/skolplattformen-app/commit/4f1f66fcbbf3682004e781d058ff43a7eb3b57ce))
-* 🎸 Started on provider for selecting platform + feature to ([1aaaeb6](https://github.com/kolplattformen/skolplattformen-app/commit/1aaaeb64e31531185c0ef75bff61c97f0cf942c4))
-* 🎸 Toggled class list in hjärntorget ([33440bc](https://github.com/kolplattformen/skolplattformen-app/commit/33440bcc32d0ea466662cdf167406b0dd503b251))
-* 🎸 wip feagture toggle ([1601c4f](https://github.com/kolplattformen/skolplattformen-app/commit/1601c4f83c75bc98ec1084725f9b126e871024b2))
-* 🎸 WIP Switch school platform ([916ebc5](https://github.com/kolplattformen/skolplattformen-app/commit/916ebc5e25b52eebf45a147f971356d8bd9e2e11))
+* 🎸 Added food menu to features ([bec62fa](https://github.com/kolplattformen/skolplattformen/commit/bec62fa21b9503927b44ad956314a888fa6923e1))
+* 🎸 Feature toggle context ([ce05682](https://github.com/kolplattformen/skolplattformen/commit/ce056821a1b1d562e4c36d7ff30dfcb5e3ad3aeb))
+* 🎸 fixes ts issues ([3f62016](https://github.com/kolplattformen/skolplattformen/commit/3f62016d6add2f5f234d6125c002b4d4603a5783))
+* 🎸 Merged with main, also added api to nx ([4f1f66f](https://github.com/kolplattformen/skolplattformen/commit/4f1f66fcbbf3682004e781d058ff43a7eb3b57ce))
+* 🎸 Started on provider for selecting platform + feature to ([1aaaeb6](https://github.com/kolplattformen/skolplattformen/commit/1aaaeb64e31531185c0ef75bff61c97f0cf942c4))
+* 🎸 Toggled class list in hjärntorget ([33440bc](https://github.com/kolplattformen/skolplattformen/commit/33440bcc32d0ea466662cdf167406b0dd503b251))
+* 🎸 wip feagture toggle ([1601c4f](https://github.com/kolplattformen/skolplattformen/commit/1601c4f83c75bc98ec1084725f9b126e871024b2))
+* 🎸 WIP Switch school platform ([916ebc5](https://github.com/kolplattformen/skolplattformen/commit/916ebc5e25b52eebf45a147f971356d8bd9e2e11))
 
-## [2.2.1](https://github.com/kolplattformen/skolplattformen-app/compare/v2.2.0...v2.2.1) (2021-11-23)
-
-
-### Bug Fixes
-
-* 🐛 spelling of chinese traditional in chinese traditional ([a28fd97](https://github.com/kolplattformen/skolplattformen-app/commit/a28fd97fe7907a591dc92f5ddeccf1045b4f794b))
-
-# [2.2.0](https://github.com/kolplattformen/skolplattformen-app/compare/v2.1.0...v2.2.0) (2021-11-23)
+## [2.2.1](https://github.com/kolplattformen/skolplattformen/compare/v2.2.0...v2.2.1) (2021-11-23)
 
 
 ### Bug Fixes
 
-* 🐛 Add languages to curriculum config ([b9302f9](https://github.com/kolplattformen/skolplattformen-app/commit/b9302f96faaf71c797ec335018d9952e26e9d267))
-* 🐛 Clarify who's personal identity number to enter ([5028a85](https://github.com/kolplattformen/skolplattformen-app/commit/5028a85824f4d73ab8007caaeca32a439f4f360e)), closes [#526](https://github.com/kolplattformen/skolplattformen-app/issues/526)
-* 🐛 fix crash when moment locale and language code differ ([623bf48](https://github.com/kolplattformen/skolplattformen-app/commit/623bf483b52a54a6199e6607248b948b775b6e7b))
-* 🐛 Fixes crash when body od newItem is empty ([3e0fd14](https://github.com/kolplattformen/skolplattformen-app/commit/3e0fd1474a719382627270a1305110692f9ff99b))
-* 🐛 Fixes failing tests (added skip), fixes lint + test ([d71c106](https://github.com/kolplattformen/skolplattformen-app/commit/d71c10607f6a4b89b582b81258fc9c0fc20bf2a8))
-* 🐛 Fixes merge with main ([c54f2ff](https://github.com/kolplattformen/skolplattformen-app/commit/c54f2ffd05589ffbebba5e50b9aef4649bfa9b58))
-* 🐛 Fixes tests ([d451cf1](https://github.com/kolplattformen/skolplattformen-app/commit/d451cf13afbf5e4d1fca43c45d3938d11503d394))
-* 🐛 Upgraded async-storage from 1.5.2 to 1.5.9 ([0cd72f5](https://github.com/kolplattformen/skolplattformen-app/commit/0cd72f5d84bd76b846d99ac7995eba3bec154866))
-* add missing package references ([d41e2e3](https://github.com/kolplattformen/skolplattformen-app/commit/d41e2e3efe278415f3afc462b721afbec4b6f1e2))
-* failing html parsing ([2a2259a](https://github.com/kolplattformen/skolplattformen-app/commit/2a2259a2608ef7e9420d9d3fa59f55530d662ae9))
-* images cropping on different devices ([#524](https://github.com/kolplattformen/skolplattformen-app/issues/524)) ([7c50988](https://github.com/kolplattformen/skolplattformen-app/commit/7c5098859b71f13ffdb9441b81e149b983355d9f))
-* licenses extractor is used on the correct package.json ([d1de447](https://github.com/kolplattformen/skolplattformen-app/commit/d1de44775b9df6132af9974f6aaef09c5f2d678f))
-* lint and prettier fixes ([169b536](https://github.com/kolplattformen/skolplattformen-app/commit/169b5365e94cd0ff5fe2aa9f28a7baebaeba899a))
-* package.json name for app changed ([a867b11](https://github.com/kolplattformen/skolplattformen-app/commit/a867b116c802956b5f5a8b6ec55e64e6821eb475))
-* remove unused e2e files ([97b4380](https://github.com/kolplattformen/skolplattformen-app/commit/97b438069a589abc37a96fe8c10ce23078b30e7b))
-* rename and fix imports ([18ed862](https://github.com/kolplattformen/skolplattformen-app/commit/18ed8620af5b396eeed740058531ebafda4f8d64))
-* some failing tests in hooks now works ([c122f28](https://github.com/kolplattformen/skolplattformen-app/commit/c122f281a9607d7a52b3a25718e93151ddd7768a))
-* ui-kitten metro config ([5fdc3d7](https://github.com/kolplattformen/skolplattformen-app/commit/5fdc3d71adb8d9364c8c6b345de841f0f3f1de7c))
-* update github workflow to run nx instead of lerna ([289c2f8](https://github.com/kolplattformen/skolplattformen-app/commit/289c2f848aec44da03692d4119aa9e1544dc9292))
+* 🐛 spelling of chinese traditional in chinese traditional ([a28fd97](https://github.com/kolplattformen/skolplattformen/commit/a28fd97fe7907a591dc92f5ddeccf1045b4f794b))
 
-
-### Features
-
-* 🎸 activate norwegian ([cec7ddd](https://github.com/kolplattformen/skolplattformen-app/commit/cec7ddd8601309f752f9fe49298fcc96643599b7))
-* 🎸 bump to version 2.0.4 ([6d762e7](https://github.com/kolplattformen/skolplattformen-app/commit/6d762e70076c292d952f1b626ea2925caaac78f9))
-* 🎸 bump to version 2.0.4 ([078c946](https://github.com/kolplattformen/skolplattformen-app/commit/078c946a441a4227033c24acbb17807ea19a4dae))
-* 🎸 Chinese (simplified and traditional) ([eed2a75](https://github.com/kolplattformen/skolplattformen-app/commit/eed2a7579c23629c0e8dbd8350fa971cec3753fb))
-* 🎸 Japanese ([e5deadd](https://github.com/kolplattformen/skolplattformen-app/commit/e5deadd88084fba26a7b8dbc83664be376b76a51))
-* 🎸 language updates for curriculum ([4d62d9e](https://github.com/kolplattformen/skolplattformen-app/commit/4d62d9e26987ae4840f81e1c1ad958a6905746c0))
-* 🎸 Latin and fix for locales ([1c05196](https://github.com/kolplattformen/skolplattformen-app/commit/1c051961d695ebb2546f2a30991d01015e7c48fb))
-* 🎸 Portuguese ([2f45cbd](https://github.com/kolplattformen/skolplattformen-app/commit/2f45cbdeb639cd43c6b13cff0a2f86a934b950dd))
-* 🎸 Somali ([df8f2e3](https://github.com/kolplattformen/skolplattformen-app/commit/df8f2e378e76d1f4b8f4b0cfd55aba82626ccaa8))
-* add nx build system ([d90cfd2](https://github.com/kolplattformen/skolplattformen-app/commit/d90cfd2a3b94b9845f809b65a96a72b10447651c))
-
-# [2.1.0](https://github.com/kolplattformen/skolplattformen-app/compare/v2.0.0...v2.1.0) (2021-10-04)
-
-
-### Features
-
-* 🎸 Use fade on the backdrop on login modal ([e99494b](https://github.com/kolplattformen/skolplattformen-app/commit/e99494bc77cf7037ca1a5076effc68c4cc3ed4ea))
-
-# [2.0.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.48.0...v2.0.0) (2021-10-03)
+# [2.2.0](https://github.com/kolplattformen/skolplattformen/compare/v2.1.0...v2.2.0) (2021-11-23)
 
 
 ### Bug Fixes
 
-* 🐛 add 2 to xsrf header and use nav controller script again ([d1a4877](https://github.com/kolplattformen/skolplattformen-app/commit/d1a4877ff457d908710020d81071955f33794ad9))
-* 🐛 add missing headers for fetching children ([68c99cb](https://github.com/kolplattformen/skolplattformen-app/commit/68c99cb1fbecd28340d1da639759fc11cb156e8c))
-* 🐛 Add personal identity number to test user ([f977143](https://github.com/kolplattformen/skolplattformen-app/commit/f97714346e671eab0a6c44b1fb5d3779d5d09d37))
-* 🐛 added "Rast" to misc words in sv,en,pl translations ([#11](https://github.com/kolplattformen/skolplattformen-app/issues/11)) ([4da06bb](https://github.com/kolplattformen/skolplattformen-app/commit/4da06bb16ee04674c5552ec37048f52a0e2a95b3))
-* 🐛 Added build step ([#38](https://github.com/kolplattformen/skolplattformen-app/issues/38)) ([db0faf2](https://github.com/kolplattformen/skolplattformen-app/commit/db0faf28bfccf8b057cf94e4b4544d52194ba6e6))
-* 🐛 Added isAuthenticated to test user ([#119](https://github.com/kolplattformen/skolplattformen-app/issues/119)) ([766f4ff](https://github.com/kolplattformen/skolplattformen-app/commit/766f4fff52ef438e79095772a0214140b0aec99e))
-* 🐛 Added luxon to fix getSchedule ([#13](https://github.com/kolplattformen/skolplattformen-app/issues/13)) ([fe1729c](https://github.com/kolplattformen/skolplattformen-app/commit/fe1729c8729d54e82edc6f287456ffc582e1bdb4))
-* 🐛 Added missing types ([3d59035](https://github.com/kolplattformen/skolplattformen-app/commit/3d59035a20a5eef2aea7f00fab09ec894a442c1d))
-* 🐛 Adjusted cookie handling ([#79](https://github.com/kolplattformen/skolplattformen-app/issues/79)) ([16020a3](https://github.com/kolplattformen/skolplattformen-app/commit/16020a3d3c9e378c2f3aec64a59d288673058473))
-* 🐛 Autopublish (I hope) ([#37](https://github.com/kolplattformen/skolplattformen-app/issues/37)) ([ed8f8a7](https://github.com/kolplattformen/skolplattformen-app/commit/ed8f8a7f5ce39a803e89b6a17972cb1aab0a266d))
-* 🐛 Build before publish ([e934950](https://github.com/kolplattformen/skolplattformen-app/commit/e934950470f4021d15f4ba424030aed47e8cbf24))
-* 🐛 Cache is no longer called in fake mode ([#3](https://github.com/kolplattformen/skolplattformen-app/issues/3)) ([f89f143](https://github.com/kolplattformen/skolplattformen-app/commit/f89f1431df4a9c24a7fc746186b78b53489eb6c6))
-* 🐛 Changed build settings ([7a7c2a1](https://github.com/kolplattformen/skolplattformen-app/commit/7a7c2a1734e24800d600a3215a2bad9016d45ed3))
-* 🐛 Cleanup on logout ([#6](https://github.com/kolplattformen/skolplattformen-app/issues/6)) ([644cbcd](https://github.com/kolplattformen/skolplattformen-app/commit/644cbcd46466491d9e9a7a35c5dca301d4403e1c))
-* 🐛 Correct format of fakeData.js ([c2adf00](https://github.com/kolplattformen/skolplattformen-app/commit/c2adf004d3da992d9380b114bed4f5f6cea91cee))
-* 🐛 Fake data included through ts ([663be5c](https://github.com/kolplattformen/skolplattformen-app/commit/663be5cc351491cf7f654f4caffea9d8537c21b1))
-* 🐛 Fix för login block 24mars ([7667a5e](https://github.com/kolplattformen/skolplattformen-app/commit/7667a5e25a9f6f79f2bb07ea8b010679a3b4528d))
-* 🐛 fix latest security "fix" ([d795458](https://github.com/kolplattformen/skolplattformen-app/commit/d7954587d5245730e504ceaa6501596962068831))
-* 🐛 fix the previous fix with a fixed json ([eefd791](https://github.com/kolplattformen/skolplattformen-app/commit/eefd79155bb436bd00233bdebf51f240640e88ae))
-* 🐛 Fixa markdownkonvertering av hårresande html ([#120](https://github.com/kolplattformen/skolplattformen-app/issues/120)) ([4991f91](https://github.com/kolplattformen/skolplattformen-app/commit/4991f910a3782545381ffabdbba89d152dfbf278))
-* 🐛 Fixar links med mellanslag ([#63](https://github.com/kolplattformen/skolplattformen-app/issues/63)) ([3edbf8c](https://github.com/kolplattformen/skolplattformen-app/commit/3edbf8c2c6ed8c34ba9e6b5d894e52e904de9662))
-* 🐛 Fixar senaste blocken ([#81](https://github.com/kolplattformen/skolplattformen-app/issues/81)) ([1ccdc9f](https://github.com/kolplattformen/skolplattformen-app/commit/1ccdc9f42ea6a11c695f12d7ef3054ffe3cdd859))
-* 🐛 Fixed fake data for notifications ([#40](https://github.com/kolplattformen/skolplattformen-app/issues/40)) ([b8621b9](https://github.com/kolplattformen/skolplattformen-app/commit/b8621b94f1131671933fa90ef12c355d92ad92e7))
-* 🐛 Fixed parsing bug for classmates ([5f07259](https://github.com/kolplattformen/skolplattformen-app/commit/5f07259ddc6dd24ed29dbff81dc03f8ae7159e81))
-* 🐛 Fixes base64 iterations ([52d7341](https://github.com/kolplattformen/skolplattformen-app/commit/52d7341e2b85ddddd9df2070cffc3322a3c58476))
-* 🐛 Fixes configuration fetch ([7bf8f1c](https://github.com/kolplattformen/skolplattformen-app/commit/7bf8f1c2a8abbc9986a016f7d6d44a3dec84da43))
-* 🐛 Fixes more sabotage from sthlm stad ([ab62ab6](https://github.com/kolplattformen/skolplattformen-app/commit/ab62ab6d356309c284a192cd63939cbc3b76ecf5))
-* 🐛 Fixes schedule ([fb65a33](https://github.com/kolplattformen/skolplattformen-app/commit/fb65a33d829e3843e6a168243e3057b988d58081))
-* 🐛 Flytta mellanslag utanför taggarna ([#124](https://github.com/kolplattformen/skolplattformen-app/issues/124)) ([79e2a75](https://github.com/kolplattformen/skolplattformen-app/commit/79e2a7577b482b2904a5aa20f3150ef1d9e5055a))
-* 🐛 Förbättrad parsning av nyhetsbrev ([#125](https://github.com/kolplattformen/skolplattformen-app/issues/125)) ([82fa2dc](https://github.com/kolplattformen/skolplattformen-app/commit/82fa2dcc844a019e71284ddae4d7cf67a2804e37))
-* 🐛 Force release ([#115](https://github.com/kolplattformen/skolplattformen-app/issues/115)) ([5c170dc](https://github.com/kolplattformen/skolplattformen-app/commit/5c170dc070752d3671afcff1d5a7b21f4af99525))
-* 🐛 Get all notifications. Add modified date to notifications ([#150](https://github.com/kolplattformen/skolplattformen-app/issues/150)) ([4a0841a](https://github.com/kolplattformen/skolplattformen-app/commit/4a0841a704cf43ba300f7be1085ff746fce972ac))
-* 🐛 hämta API key från server ([9bde441](https://github.com/kolplattformen/skolplattformen-app/commit/9bde441907dc90daa3ab001acbd243dfb3323a17))
-* 🐛 implemented XSRF token support ([1ecfdaf](https://github.com/kolplattformen/skolplattformen-app/commit/1ecfdafede92dfffe302ab6dea46c63b05bb60ea))
-* 🐛 Moved topologykey to config, also added getHeader() ([2823547](https://github.com/kolplattformen/skolplattformen-app/commit/28235478041ad3f38fcecc5ebbcf236e2530e018))
-* 🐛 News item details now gets parsed ([#55](https://github.com/kolplattformen/skolplattformen-app/issues/55)) ([50ce985](https://github.com/kolplattformen/skolplattformen-app/commit/50ce985edcc92205f39f9fa126fb25fb746aaf23))
-* 🐛 Ny version av curriculum ([#148](https://github.com/kolplattformen/skolplattformen-app/issues/148)) ([e54ed25](https://github.com/kolplattformen/skolplattformen-app/commit/e54ed25d9ff7df7baf78c8356a8682d5ad75bb92))
-* 🐛 Parse old aspnet dates instead of unreliable format strings ([#108](https://github.com/kolplattformen/skolplattformen-app/issues/108)) ([3c33c75](https://github.com/kolplattformen/skolplattformen-app/commit/3c33c75956dc401338b64acf6d946b64d7dfce5c)), closes [#105](https://github.com/kolplattformen/skolplattformen-app/issues/105)
-* 🐛 Parsning ([83ec383](https://github.com/kolplattformen/skolplattformen-app/commit/83ec3833c3d8d966e27ffb976ab655410a2630ac))
-* 🐛 read xsrf token from script for createItem call ([1deb424](https://github.com/kolplattformen/skolplattformen-app/commit/1deb42430ce8eb76b2a3956c9a9fba87ba70443f))
-* 🐛 Reload anropar bara apiet om den inte redan laddar ([#9](https://github.com/kolplattformen/skolplattformen-app/issues/9)) ([c329283](https://github.com/kolplattformen/skolplattformen-app/commit/c32928369be6be104ede4c7090ed98246795fe87))
-* 🐛 reload inaktivt i fejk ([#10](https://github.com/kolplattformen/skolplattformen-app/issues/10)) ([9fa63e8](https://github.com/kolplattformen/skolplattformen-app/commit/9fa63e84fea5e9ede12f955ff11041504c4f1292))
-* 🐛 Removed dynamic require ([#8](https://github.com/kolplattformen/skolplattformen-app/issues/8)) ([a3421b8](https://github.com/kolplattformen/skolplattformen-app/commit/a3421b8772b522cdb36bc3b0de87e13507ab976c))
-* 🐛 Removed superfluous property in en.json ([#5](https://github.com/kolplattformen/skolplattformen-app/issues/5)) ([b6137ab](https://github.com/kolplattformen/skolplattformen-app/commit/b6137abb059ba2e6a57f594b77befc0881d7ebbf))
-* 🐛 rensa upp getChildren anropet och ny release ([2336861](https://github.com/kolplattformen/skolplattformen-app/commit/2336861a71881fdb08d3a57b0b5fbe072dc08f0e))
-* 🐛 Repaired login ([#11](https://github.com/kolplattformen/skolplattformen-app/issues/11)) ([83a4737](https://github.com/kolplattformen/skolplattformen-app/commit/83a47375945472c3c6809ed5e24ca481d2577f34))
-* 🐛 Replaced named capture group for compatibility reasons ([#112](https://github.com/kolplattformen/skolplattformen-app/issues/112)) ([66b23fa](https://github.com/kolplattformen/skolplattformen-app/commit/66b23faf4392c942467334664d32a57be72e9758))
-* 🐛 Replaces non breaking space with simple space ([#57](https://github.com/kolplattformen/skolplattformen-app/issues/57)) ([58d5676](https://github.com/kolplattformen/skolplattformen-app/commit/58d56764d3bdc10a5681d288c47b68d1cc9aa936))
-* 🐛 Return a empty array if backend returns a specific error ([1e944ad](https://github.com/kolplattformen/skolplattformen-app/commit/1e944adf24482fef472174d14c9d76fc9e3bf78b))
-* 🐛 semikolonviolation! ([46c6260](https://github.com/kolplattformen/skolplattformen-app/commit/46c62601a2a56bf9966594a2842434701213dd27))
-* 🐛 Silly stockholm stad protection ([cd19abd](https://github.com/kolplattformen/skolplattformen-app/commit/cd19abdd0f7f16ffc7b2a4e2de598e00e832f8c3))
-* 🐛 Tog bort radbrytning i bold ([#66](https://github.com/kolplattformen/skolplattformen-app/issues/66)) ([ca0117c](https://github.com/kolplattformen/skolplattformen-app/commit/ca0117ce64fbf1ce7eb6f476c37fc769e3df561e))
-* 🐛 Trims tag content to fix some markdown issues ([#56](https://github.com/kolplattformen/skolplattformen-app/issues/56)) ([f9dc391](https://github.com/kolplattformen/skolplattformen-app/commit/f9dc39128e1af21c4aaa23ca68cd81dcb9935448))
-* 🐛 URLSearchParams compatible with both node and RN ([#111](https://github.com/kolplattformen/skolplattformen-app/issues/111)) ([fd919a0](https://github.com/kolplattformen/skolplattformen-app/commit/fd919a0b5e961af00050e6c12a997bb6aa60d9ad))
-* 🐛 use childcontroller script for XSRF header to CreateItem ([2796875](https://github.com/kolplattformen/skolplattformen-app/commit/2796875fe2593d5dc8f1be573f0f27ddb3216342))
-* 🐛 Working notification url:s ([#41](https://github.com/kolplattformen/skolplattformen-app/issues/41)) ([3a808f9](https://github.com/kolplattformen/skolplattformen-app/commit/3a808f9ccd67994a615339223539fe8c5f51fc0a))
-* add date handler ([a3e0eba](https://github.com/kolplattformen/skolplattformen-app/commit/a3e0eba706dd855af0e06775e913000c531b9f6e))
-* correct fake data dates ([d88bfcf](https://github.com/kolplattformen/skolplattformen-app/commit/d88bfcf5641e4dff89d6af6709fea00cae5a4c5b))
-* handle iso date strings ([ca0a3e4](https://github.com/kolplattformen/skolplattformen-app/commit/ca0a3e49aca34edab2881eb38349d866928c29ab))
-* handle long dates with time ([3ba96fe](https://github.com/kolplattformen/skolplattformen-app/commit/3ba96feec9804cb945d9a09d709461ac4c61d902))
-* handle missing spaces in intro after certain characters ([#99](https://github.com/kolplattformen/skolplattformen-app/issues/99)) ([2926de3](https://github.com/kolplattformen/skolplattformen-app/commit/2926de31fe938cc5dd8284d47119454e4dee14a1))
-* links ([#64](https://github.com/kolplattformen/skolplattformen-app/issues/64)) ([905b893](https://github.com/kolplattformen/skolplattformen-app/commit/905b893ca735ffe9f7625d9eae18dbb2c12f1b1f))
-* parse calendar dates as utc before iso ([#100](https://github.com/kolplattformen/skolplattformen-app/issues/100)) ([73f6d8b](https://github.com/kolplattformen/skolplattformen-app/commit/73f6d8ba72bfdbb018fb564abcd4ad55bf288a3e))
-* parse intro without positive lookbehind regex ([#102](https://github.com/kolplattformen/skolplattformen-app/issues/102)) ([f8b3df2](https://github.com/kolplattformen/skolplattformen-app/commit/f8b3df2936c0eed0dec226c56cbd062272629655))
-* Translations update from Weblate ([#16](https://github.com/kolplattformen/skolplattformen-app/issues/16)) ([94a3883](https://github.com/kolplattformen/skolplattformen-app/commit/94a38833c14124c84277ca9a79cb7630226b2948))
-* use date constructor instead of luxon ([74ea878](https://github.com/kolplattformen/skolplattformen-app/commit/74ea878073bc72934793604b00797264ca252afa))
-* use parseDate for all date handling ([6cd92ac](https://github.com/kolplattformen/skolplattformen-app/commit/6cd92acbe326e6622df49832e3a46cb57e6f92a1))
+* 🐛 Add languages to curriculum config ([b9302f9](https://github.com/kolplattformen/skolplattformen/commit/b9302f96faaf71c797ec335018d9952e26e9d267))
+* 🐛 Clarify who's personal identity number to enter ([5028a85](https://github.com/kolplattformen/skolplattformen/commit/5028a85824f4d73ab8007caaeca32a439f4f360e)), closes [#526](https://github.com/kolplattformen/skolplattformen/issues/526)
+* 🐛 fix crash when moment locale and language code differ ([623bf48](https://github.com/kolplattformen/skolplattformen/commit/623bf483b52a54a6199e6607248b948b775b6e7b))
+* 🐛 Fixes crash when body od newItem is empty ([3e0fd14](https://github.com/kolplattformen/skolplattformen/commit/3e0fd1474a719382627270a1305110692f9ff99b))
+* 🐛 Fixes failing tests (added skip), fixes lint + test ([d71c106](https://github.com/kolplattformen/skolplattformen/commit/d71c10607f6a4b89b582b81258fc9c0fc20bf2a8))
+* 🐛 Fixes merge with main ([c54f2ff](https://github.com/kolplattformen/skolplattformen/commit/c54f2ffd05589ffbebba5e50b9aef4649bfa9b58))
+* 🐛 Fixes tests ([d451cf1](https://github.com/kolplattformen/skolplattformen/commit/d451cf13afbf5e4d1fca43c45d3938d11503d394))
+* 🐛 Upgraded async-storage from 1.5.2 to 1.5.9 ([0cd72f5](https://github.com/kolplattformen/skolplattformen/commit/0cd72f5d84bd76b846d99ac7995eba3bec154866))
+* add missing package references ([d41e2e3](https://github.com/kolplattformen/skolplattformen/commit/d41e2e3efe278415f3afc462b721afbec4b6f1e2))
+* failing html parsing ([2a2259a](https://github.com/kolplattformen/skolplattformen/commit/2a2259a2608ef7e9420d9d3fa59f55530d662ae9))
+* images cropping on different devices ([#524](https://github.com/kolplattformen/skolplattformen/issues/524)) ([7c50988](https://github.com/kolplattformen/skolplattformen/commit/7c5098859b71f13ffdb9441b81e149b983355d9f))
+* licenses extractor is used on the correct package.json ([d1de447](https://github.com/kolplattformen/skolplattformen/commit/d1de44775b9df6132af9974f6aaef09c5f2d678f))
+* lint and prettier fixes ([169b536](https://github.com/kolplattformen/skolplattformen/commit/169b5365e94cd0ff5fe2aa9f28a7baebaeba899a))
+* package.json name for app changed ([a867b11](https://github.com/kolplattformen/skolplattformen/commit/a867b116c802956b5f5a8b6ec55e64e6821eb475))
+* remove unused e2e files ([97b4380](https://github.com/kolplattformen/skolplattformen/commit/97b438069a589abc37a96fe8c10ce23078b30e7b))
+* rename and fix imports ([18ed862](https://github.com/kolplattformen/skolplattformen/commit/18ed8620af5b396eeed740058531ebafda4f8d64))
+* some failing tests in hooks now works ([c122f28](https://github.com/kolplattformen/skolplattformen/commit/c122f281a9607d7a52b3a25718e93151ddd7768a))
+* ui-kitten metro config ([5fdc3d7](https://github.com/kolplattformen/skolplattformen/commit/5fdc3d71adb8d9364c8c6b345de841f0f3f1de7c))
+* update github workflow to run nx instead of lerna ([289c2f8](https://github.com/kolplattformen/skolplattformen/commit/289c2f848aec44da03692d4119aa9e1544dc9292))
 
 
 ### Features
 
-* 🎸 Added .author and .imageAltText on NewsItem ([#42](https://github.com/kolplattformen/skolplattformen-app/issues/42)) ([6e84a63](https://github.com/kolplattformen/skolplattformen-app/commit/6e84a6391a9702503ceda89f1399a9c600b2315d))
-* 🎸 Added getter for logged in personal number ([#39](https://github.com/kolplattformen/skolplattformen-app/issues/39)) ([a860d12](https://github.com/kolplattformen/skolplattformen-app/commit/a860d1208c5d79f0d06034ebd993bc1f3cf2eb5e))
-* 🎸 Added language support ([#121](https://github.com/kolplattformen/skolplattformen-app/issues/121)) ([9dcdf78](https://github.com/kolplattformen/skolplattformen-app/commit/9dcdf78515a944bb48fffecc9af5072dab8fe851))
-* 🎸 Alla nyhetsbrev ([#67](https://github.com/kolplattformen/skolplattformen-app/issues/67)) ([f3f658f](https://github.com/kolplattformen/skolplattformen-app/commit/f3f658fdd33300304f9969bae7d892359859293f))
-* 🎸 API call retries and support for error reporting ([#5](https://github.com/kolplattformen/skolplattformen-app/issues/5)) ([9ed5df2](https://github.com/kolplattformen/skolplattformen-app/commit/9ed5df2e45e8d368d3d4df1c992a0901a512ff6a))
-* 🎸 Build, tag and release ([b71adc5](https://github.com/kolplattformen/skolplattformen-app/commit/b71adc57fbdd4ff4d6fe1b87e7afac90a9d6628c))
-* 🎸 cache busting ([5ce4ddd](https://github.com/kolplattformen/skolplattformen-app/commit/5ce4ddd9d04501a15ce37c9f3378e36b3f3dabfe))
-* 🎸 Cache prefixas med personnummer ([#8](https://github.com/kolplattformen/skolplattformen-app/issues/8)) ([fc146ea](https://github.com/kolplattformen/skolplattformen-app/commit/fc146ea7fc9f705b88bbc75a6cc01b6f2235bfaa))
-* 🎸 Classmates ([#14](https://github.com/kolplattformen/skolplattformen-app/issues/14)) ([a6ce6ea](https://github.com/kolplattformen/skolplattformen-app/commit/a6ce6ea9f6468ad5c1e26df4228706a1055e241a)), closes [#7](https://github.com/kolplattformen/skolplattformen-app/issues/7)
-* 🎸 Code cleanup, refactoring, linting and tests ([d0a0314](https://github.com/kolplattformen/skolplattformen-app/commit/d0a0314ae6f058c617227d28d738bff9fc85e966))
-* 🎸 Curriculum as peer dependency ([#122](https://github.com/kolplattformen/skolplattformen-app/issues/122)) ([e24a9b3](https://github.com/kolplattformen/skolplattformen-app/commit/e24a9b3c5e0d64a395e4b576975cc2b3e6832bab))
-* 🎸 Exporting all types in index ([#45](https://github.com/kolplattformen/skolplattformen-app/issues/45)) ([8351ef2](https://github.com/kolplattformen/skolplattformen-app/commit/8351ef275f1ac87da00fdeaa86a3f4e17a1e15b1))
-* 🎸 Exporting LoginStatusChecker interface ([#46](https://github.com/kolplattformen/skolplattformen-app/issues/46)) ([20e18e5](https://github.com/kolplattformen/skolplattformen-app/commit/20e18e5e23e1a1def00667a3f23e9992511a708b))
-* 🎸 Fake mode for 121212121212, 201212121212 and 1212121212 ([#35](https://github.com/kolplattformen/skolplattformen-app/issues/35)) ([8d264b9](https://github.com/kolplattformen/skolplattformen-app/commit/8d264b9787f20c2c93348f9538d1775a8b931d05))
-* 🎸 Fakedata laggar 0.2-1 sekund ([#68](https://github.com/kolplattformen/skolplattformen-app/issues/68)) ([018d600](https://github.com/kolplattformen/skolplattformen-app/commit/018d60099dffbb57c387367a31a091620f5132a7))
-* 🎸 Fallback language ([#7](https://github.com/kolplattformen/skolplattformen-app/issues/7)) ([e944468](https://github.com/kolplattformen/skolplattformen-app/commit/e94446873429438b79a81542caf8f4f4f1882ce0))
-* 🎸 First implementation ([e5438b0](https://github.com/kolplattformen/skolplattformen-app/commit/e5438b0f264afb564efec7aca46adad0db6bd6e2))
-* 🎸 First release ([d37f3db](https://github.com/kolplattformen/skolplattformen-app/commit/d37f3db3e8df421bb1ed8848ab63220a9b461b24))
-* 🎸 Forcing release ([d4151fa](https://github.com/kolplattformen/skolplattformen-app/commit/d4151fa26faa3017d5c36ca3eef4966db6d7267b))
-* 🎸 getSessionCookie and removed News object ([#24](https://github.com/kolplattformen/skolplattformen-app/issues/24)) ([91ba683](https://github.com/kolplattformen/skolplattformen-app/commit/91ba6833b456dd446948c886c80768d2af360a25)), closes [#22](https://github.com/kolplattformen/skolplattformen-app/issues/22) [#23](https://github.com/kolplattformen/skolplattformen-app/issues/23)
-* 🎸 getUser ([#19](https://github.com/kolplattformen/skolplattformen-app/issues/19)) ([39b62b7](https://github.com/kolplattformen/skolplattformen-app/commit/39b62b7b371b0990e9c4594603e8e95219234dd5)), closes [#9](https://github.com/kolplattformen/skolplattformen-app/issues/9)
-* 🎸 Hämta lektionsschema ([#110](https://github.com/kolplattformen/skolplattformen-app/issues/110)) ([c288449](https://github.com/kolplattformen/skolplattformen-app/commit/c2884497bf66fccbae79883e3e1d9470d7c9fc55))
-* 🎸 Image ([#21](https://github.com/kolplattformen/skolplattformen-app/issues/21)) ([2ad7523](https://github.com/kolplattformen/skolplattformen-app/commit/2ad7523a1ded17bbb20b491cd54cd9c960c825a3)), closes [#10](https://github.com/kolplattformen/skolplattformen-app/issues/10)
-* 🎸 It now handles comments ([065e0e9](https://github.com/kolplattformen/skolplattformen-app/commit/065e0e968276bc385ecec314a5577a5be44bfaf6))
-* 🎸 Loads schedule ([#16](https://github.com/kolplattformen/skolplattformen-app/issues/16)) ([53d42de](https://github.com/kolplattformen/skolplattformen-app/commit/53d42de62cae311e28decf50591e521128c9bfcb)), closes [#13](https://github.com/kolplattformen/skolplattformen-app/issues/13) [#8](https://github.com/kolplattformen/skolplattformen-app/issues/8)
-* 🎸 Made User properties optional for hook convenience ([#31](https://github.com/kolplattformen/skolplattformen-app/issues/31)) ([0e0e996](https://github.com/kolplattformen/skolplattformen-app/commit/0e0e9965892e69819e9b49dfcdf2afdddacccb47))
-* 🎸 Misc codes (Lunch, Prandium, MTID) ([59e350b](https://github.com/kolplattformen/skolplattformen-app/commit/59e350b6ab6d1164d64b84428226a0c6e078c622))
-* 🎸 Multilang support for useTimetable ([#14](https://github.com/kolplattformen/skolplattformen-app/issues/14)) ([be6c9d1](https://github.com/kolplattformen/skolplattformen-app/commit/be6c9d1302a8f098bf1d57058285c90745ca9626))
-* 🎸 Names from curriculum ([#116](https://github.com/kolplattformen/skolplattformen-app/issues/116)) ([504503f](https://github.com/kolplattformen/skolplattformen-app/commit/504503f7a0c243b5d24f1784ad83af2e9d01feee))
-* 🎸 New properties on NewsItem and updated fake data ([#44](https://github.com/kolplattformen/skolplattformen-app/issues/44)) ([dea899b](https://github.com/kolplattformen/skolplattformen-app/commit/dea899bd17d43bf95936065bb92a523dd3da79f2))
-* 🎸 News are sorted, desc, by modified date ([#147](https://github.com/kolplattformen/skolplattformen-app/issues/147)) ([a4b7b7f](https://github.com/kolplattformen/skolplattformen-app/commit/a4b7b7f6a942e2bdedd82c50e16f5336bb6fc1ec))
-* 🎸 News images that do not require login ([#43](https://github.com/kolplattformen/skolplattformen-app/issues/43)) ([5daf186](https://github.com/kolplattformen/skolplattformen-app/commit/5daf186d5cd6ff7084ea7bbc38d9586c1ec9b59e))
-* 🎸 Notifications ([#20](https://github.com/kolplattformen/skolplattformen-app/issues/20)) ([348e437](https://github.com/kolplattformen/skolplattformen-app/commit/348e43778df7e7336148b327a0ce2363bca05fa4)), closes [#11](https://github.com/kolplattformen/skolplattformen-app/issues/11)
-* 🎸 Notifications sorted by modified, then created date ([#151](https://github.com/kolplattformen/skolplattformen-app/issues/151)) ([91f63e8](https://github.com/kolplattformen/skolplattformen-app/commit/91f63e8d2ac060692090d8f75379a3a7c6a1a074))
-* 🎸 Polish ([#9](https://github.com/kolplattformen/skolplattformen-app/issues/9)) ([18c8126](https://github.com/kolplattformen/skolplattformen-app/commit/18c81264a08123526989d33ee1dd1ade08c38d8d))
-* 🎸 Possibly first working version ([0e4acba](https://github.com/kolplattformen/skolplattformen-app/commit/0e4acba776558aa25f00347ac38cdd2d873da657))
-* 🎸 Remove all obsolete login obstacles ([#146](https://github.com/kolplattformen/skolplattformen-app/issues/146)) ([befb073](https://github.com/kolplattformen/skolplattformen-app/commit/befb073a322823dfad2b29e8ab03488b68f2a16c))
-* 🎸 Remove required personal number in route ([#118](https://github.com/kolplattformen/skolplattformen-app/issues/118)) ([c3b4b15](https://github.com/kolplattformen/skolplattformen-app/commit/c3b4b153c34de34d85681f41dbdfd0c1f5d356bd))
-* 🎸 Removed getImage() and added .fullImageUrl to NewsItem ([#33](https://github.com/kolplattformen/skolplattformen-app/issues/33)) ([5c3929d](https://github.com/kolplattformen/skolplattformen-app/commit/5c3929d9d171f720b60369b4f5fe105da83af6b0))
-* 🎸 Replaced Moment with Luxon ([#30](https://github.com/kolplattformen/skolplattformen-app/issues/30)) ([e41f0bf](https://github.com/kolplattformen/skolplattformen-app/commit/e41f0bf4357ddb762667c6837d54726addc8fd44))
-* 🎸 Släpp sargen - nu kör vi ([#60](https://github.com/kolplattformen/skolplattformen-app/issues/60)) ([c5e9992](https://github.com/kolplattformen/skolplattformen-app/commit/c5e9992f9ab204799aad5d040b26d62e33703aff))
-* 🎸 Switched to Markdown Extra converter ([#58](https://github.com/kolplattformen/skolplattformen-app/issues/58)) ([3b7b067](https://github.com/kolplattformen/skolplattformen-app/commit/3b7b0677a457673d225511c43ca00add73498930))
-* 🎸 Timetables ([#12](https://github.com/kolplattformen/skolplattformen-app/issues/12)) ([2ae212d](https://github.com/kolplattformen/skolplattformen-app/commit/2ae212d46a7c8c333101f39e76435721c8d0d00e))
-* 🎸 Updated curriculum and fake data with new codes ([#117](https://github.com/kolplattformen/skolplattformen-app/issues/117)) ([0a02ffa](https://github.com/kolplattformen/skolplattformen-app/commit/0a02ffa04d7d7e6610bf2f2fffa83a683fc23726))
-* 🎸 useNewsDetails(child, news) ([5d4f751](https://github.com/kolplattformen/skolplattformen-app/commit/5d4f7515cd7af66e5a192520bf7d96aab72e8bf5))
-* add newsItemDetails ([1826b80](https://github.com/kolplattformen/skolplattformen-app/commit/1826b80d4bd2ee97fedb1f04f70a95bb478878de))
-* call newsItemDetails to get details for a news item. Resolves [#28](https://github.com/kolplattformen/skolplattformen-app/issues/28) ([5dcc42e](https://github.com/kolplattformen/skolplattformen-app/commit/5dcc42eeac0b4acda11515271b63aeb42e3773d9))
-* Improve menu ([#109](https://github.com/kolplattformen/skolplattformen-app/issues/109)) ([9c4fcb2](https://github.com/kolplattformen/skolplattformen-app/commit/9c4fcb2d251d71ec076e3b1725ae74b497535d66))
-* Ombyggd parsning av nyhetsbrev ([#65](https://github.com/kolplattformen/skolplattformen-app/issues/65)) ([a5dfb70](https://github.com/kolplattformen/skolplattformen-app/commit/a5dfb704f4c7428b148cd26f94eceb9567bfb35e))
-* update typings for ScheduleItem ([9c87535](https://github.com/kolplattformen/skolplattformen-app/commit/9c87535c5bd8e1c9ed8e66d03c13cb6dc8cce8fb))
+* 🎸 activate norwegian ([cec7ddd](https://github.com/kolplattformen/skolplattformen/commit/cec7ddd8601309f752f9fe49298fcc96643599b7))
+* 🎸 bump to version 2.0.4 ([6d762e7](https://github.com/kolplattformen/skolplattformen/commit/6d762e70076c292d952f1b626ea2925caaac78f9))
+* 🎸 bump to version 2.0.4 ([078c946](https://github.com/kolplattformen/skolplattformen/commit/078c946a441a4227033c24acbb17807ea19a4dae))
+* 🎸 Chinese (simplified and traditional) ([eed2a75](https://github.com/kolplattformen/skolplattformen/commit/eed2a7579c23629c0e8dbd8350fa971cec3753fb))
+* 🎸 Japanese ([e5deadd](https://github.com/kolplattformen/skolplattformen/commit/e5deadd88084fba26a7b8dbc83664be376b76a51))
+* 🎸 language updates for curriculum ([4d62d9e](https://github.com/kolplattformen/skolplattformen/commit/4d62d9e26987ae4840f81e1c1ad958a6905746c0))
+* 🎸 Latin and fix for locales ([1c05196](https://github.com/kolplattformen/skolplattformen/commit/1c051961d695ebb2546f2a30991d01015e7c48fb))
+* 🎸 Portuguese ([2f45cbd](https://github.com/kolplattformen/skolplattformen/commit/2f45cbdeb639cd43c6b13cff0a2f86a934b950dd))
+* 🎸 Somali ([df8f2e3](https://github.com/kolplattformen/skolplattformen/commit/df8f2e378e76d1f4b8f4b0cfd55aba82626ccaa8))
+* add nx build system ([d90cfd2](https://github.com/kolplattformen/skolplattformen/commit/d90cfd2a3b94b9845f809b65a96a72b10447651c))
+
+# [2.1.0](https://github.com/kolplattformen/skolplattformen/compare/v2.0.0...v2.1.0) (2021-10-04)
 
 
-* Rebuilt session handling and login (#78) ([c62dab9](https://github.com/kolplattformen/skolplattformen-app/commit/c62dab9e2e9be4b208f0cb2fc9bb6253beb2b403)), closes [#78](https://github.com/kolplattformen/skolplattformen-app/issues/78)
+### Features
+
+* 🎸 Use fade on the backdrop on login modal ([e99494b](https://github.com/kolplattformen/skolplattformen/commit/e99494bc77cf7037ca1a5076effc68c4cc3ed4ea))
+
+# [2.0.0](https://github.com/kolplattformen/skolplattformen/compare/v1.48.0...v2.0.0) (2021-10-03)
+
+
+### Bug Fixes
+
+* 🐛 add 2 to xsrf header and use nav controller script again ([d1a4877](https://github.com/kolplattformen/skolplattformen/commit/d1a4877ff457d908710020d81071955f33794ad9))
+* 🐛 add missing headers for fetching children ([68c99cb](https://github.com/kolplattformen/skolplattformen/commit/68c99cb1fbecd28340d1da639759fc11cb156e8c))
+* 🐛 Add personal identity number to test user ([f977143](https://github.com/kolplattformen/skolplattformen/commit/f97714346e671eab0a6c44b1fb5d3779d5d09d37))
+* 🐛 added "Rast" to misc words in sv,en,pl translations ([#11](https://github.com/kolplattformen/skolplattformen/issues/11)) ([4da06bb](https://github.com/kolplattformen/skolplattformen/commit/4da06bb16ee04674c5552ec37048f52a0e2a95b3))
+* 🐛 Added build step ([#38](https://github.com/kolplattformen/skolplattformen/issues/38)) ([db0faf2](https://github.com/kolplattformen/skolplattformen/commit/db0faf28bfccf8b057cf94e4b4544d52194ba6e6))
+* 🐛 Added isAuthenticated to test user ([#119](https://github.com/kolplattformen/skolplattformen/issues/119)) ([766f4ff](https://github.com/kolplattformen/skolplattformen/commit/766f4fff52ef438e79095772a0214140b0aec99e))
+* 🐛 Added luxon to fix getSchedule ([#13](https://github.com/kolplattformen/skolplattformen/issues/13)) ([fe1729c](https://github.com/kolplattformen/skolplattformen/commit/fe1729c8729d54e82edc6f287456ffc582e1bdb4))
+* 🐛 Added missing types ([3d59035](https://github.com/kolplattformen/skolplattformen/commit/3d59035a20a5eef2aea7f00fab09ec894a442c1d))
+* 🐛 Adjusted cookie handling ([#79](https://github.com/kolplattformen/skolplattformen/issues/79)) ([16020a3](https://github.com/kolplattformen/skolplattformen/commit/16020a3d3c9e378c2f3aec64a59d288673058473))
+* 🐛 Autopublish (I hope) ([#37](https://github.com/kolplattformen/skolplattformen/issues/37)) ([ed8f8a7](https://github.com/kolplattformen/skolplattformen/commit/ed8f8a7f5ce39a803e89b6a17972cb1aab0a266d))
+* 🐛 Build before publish ([e934950](https://github.com/kolplattformen/skolplattformen/commit/e934950470f4021d15f4ba424030aed47e8cbf24))
+* 🐛 Cache is no longer called in fake mode ([#3](https://github.com/kolplattformen/skolplattformen/issues/3)) ([f89f143](https://github.com/kolplattformen/skolplattformen/commit/f89f1431df4a9c24a7fc746186b78b53489eb6c6))
+* 🐛 Changed build settings ([7a7c2a1](https://github.com/kolplattformen/skolplattformen/commit/7a7c2a1734e24800d600a3215a2bad9016d45ed3))
+* 🐛 Cleanup on logout ([#6](https://github.com/kolplattformen/skolplattformen/issues/6)) ([644cbcd](https://github.com/kolplattformen/skolplattformen/commit/644cbcd46466491d9e9a7a35c5dca301d4403e1c))
+* 🐛 Correct format of fakeData.js ([c2adf00](https://github.com/kolplattformen/skolplattformen/commit/c2adf004d3da992d9380b114bed4f5f6cea91cee))
+* 🐛 Fake data included through ts ([663be5c](https://github.com/kolplattformen/skolplattformen/commit/663be5cc351491cf7f654f4caffea9d8537c21b1))
+* 🐛 Fix för login block 24mars ([7667a5e](https://github.com/kolplattformen/skolplattformen/commit/7667a5e25a9f6f79f2bb07ea8b010679a3b4528d))
+* 🐛 fix latest security "fix" ([d795458](https://github.com/kolplattformen/skolplattformen/commit/d7954587d5245730e504ceaa6501596962068831))
+* 🐛 fix the previous fix with a fixed json ([eefd791](https://github.com/kolplattformen/skolplattformen/commit/eefd79155bb436bd00233bdebf51f240640e88ae))
+* 🐛 Fixa markdownkonvertering av hårresande html ([#120](https://github.com/kolplattformen/skolplattformen/issues/120)) ([4991f91](https://github.com/kolplattformen/skolplattformen/commit/4991f910a3782545381ffabdbba89d152dfbf278))
+* 🐛 Fixar links med mellanslag ([#63](https://github.com/kolplattformen/skolplattformen/issues/63)) ([3edbf8c](https://github.com/kolplattformen/skolplattformen/commit/3edbf8c2c6ed8c34ba9e6b5d894e52e904de9662))
+* 🐛 Fixar senaste blocken ([#81](https://github.com/kolplattformen/skolplattformen/issues/81)) ([1ccdc9f](https://github.com/kolplattformen/skolplattformen/commit/1ccdc9f42ea6a11c695f12d7ef3054ffe3cdd859))
+* 🐛 Fixed fake data for notifications ([#40](https://github.com/kolplattformen/skolplattformen/issues/40)) ([b8621b9](https://github.com/kolplattformen/skolplattformen/commit/b8621b94f1131671933fa90ef12c355d92ad92e7))
+* 🐛 Fixed parsing bug for classmates ([5f07259](https://github.com/kolplattformen/skolplattformen/commit/5f07259ddc6dd24ed29dbff81dc03f8ae7159e81))
+* 🐛 Fixes base64 iterations ([52d7341](https://github.com/kolplattformen/skolplattformen/commit/52d7341e2b85ddddd9df2070cffc3322a3c58476))
+* 🐛 Fixes configuration fetch ([7bf8f1c](https://github.com/kolplattformen/skolplattformen/commit/7bf8f1c2a8abbc9986a016f7d6d44a3dec84da43))
+* 🐛 Fixes more sabotage from sthlm stad ([ab62ab6](https://github.com/kolplattformen/skolplattformen/commit/ab62ab6d356309c284a192cd63939cbc3b76ecf5))
+* 🐛 Fixes schedule ([fb65a33](https://github.com/kolplattformen/skolplattformen/commit/fb65a33d829e3843e6a168243e3057b988d58081))
+* 🐛 Flytta mellanslag utanför taggarna ([#124](https://github.com/kolplattformen/skolplattformen/issues/124)) ([79e2a75](https://github.com/kolplattformen/skolplattformen/commit/79e2a7577b482b2904a5aa20f3150ef1d9e5055a))
+* 🐛 Förbättrad parsning av nyhetsbrev ([#125](https://github.com/kolplattformen/skolplattformen/issues/125)) ([82fa2dc](https://github.com/kolplattformen/skolplattformen/commit/82fa2dcc844a019e71284ddae4d7cf67a2804e37))
+* 🐛 Force release ([#115](https://github.com/kolplattformen/skolplattformen/issues/115)) ([5c170dc](https://github.com/kolplattformen/skolplattformen/commit/5c170dc070752d3671afcff1d5a7b21f4af99525))
+* 🐛 Get all notifications. Add modified date to notifications ([#150](https://github.com/kolplattformen/skolplattformen/issues/150)) ([4a0841a](https://github.com/kolplattformen/skolplattformen/commit/4a0841a704cf43ba300f7be1085ff746fce972ac))
+* 🐛 hämta API key från server ([9bde441](https://github.com/kolplattformen/skolplattformen/commit/9bde441907dc90daa3ab001acbd243dfb3323a17))
+* 🐛 implemented XSRF token support ([1ecfdaf](https://github.com/kolplattformen/skolplattformen/commit/1ecfdafede92dfffe302ab6dea46c63b05bb60ea))
+* 🐛 Moved topologykey to config, also added getHeader() ([2823547](https://github.com/kolplattformen/skolplattformen/commit/28235478041ad3f38fcecc5ebbcf236e2530e018))
+* 🐛 News item details now gets parsed ([#55](https://github.com/kolplattformen/skolplattformen/issues/55)) ([50ce985](https://github.com/kolplattformen/skolplattformen/commit/50ce985edcc92205f39f9fa126fb25fb746aaf23))
+* 🐛 Ny version av curriculum ([#148](https://github.com/kolplattformen/skolplattformen/issues/148)) ([e54ed25](https://github.com/kolplattformen/skolplattformen/commit/e54ed25d9ff7df7baf78c8356a8682d5ad75bb92))
+* 🐛 Parse old aspnet dates instead of unreliable format strings ([#108](https://github.com/kolplattformen/skolplattformen/issues/108)) ([3c33c75](https://github.com/kolplattformen/skolplattformen/commit/3c33c75956dc401338b64acf6d946b64d7dfce5c)), closes [#105](https://github.com/kolplattformen/skolplattformen/issues/105)
+* 🐛 Parsning ([83ec383](https://github.com/kolplattformen/skolplattformen/commit/83ec3833c3d8d966e27ffb976ab655410a2630ac))
+* 🐛 read xsrf token from script for createItem call ([1deb424](https://github.com/kolplattformen/skolplattformen/commit/1deb42430ce8eb76b2a3956c9a9fba87ba70443f))
+* 🐛 Reload anropar bara apiet om den inte redan laddar ([#9](https://github.com/kolplattformen/skolplattformen/issues/9)) ([c329283](https://github.com/kolplattformen/skolplattformen/commit/c32928369be6be104ede4c7090ed98246795fe87))
+* 🐛 reload inaktivt i fejk ([#10](https://github.com/kolplattformen/skolplattformen/issues/10)) ([9fa63e8](https://github.com/kolplattformen/skolplattformen/commit/9fa63e84fea5e9ede12f955ff11041504c4f1292))
+* 🐛 Removed dynamic require ([#8](https://github.com/kolplattformen/skolplattformen/issues/8)) ([a3421b8](https://github.com/kolplattformen/skolplattformen/commit/a3421b8772b522cdb36bc3b0de87e13507ab976c))
+* 🐛 Removed superfluous property in en.json ([#5](https://github.com/kolplattformen/skolplattformen/issues/5)) ([b6137ab](https://github.com/kolplattformen/skolplattformen/commit/b6137abb059ba2e6a57f594b77befc0881d7ebbf))
+* 🐛 rensa upp getChildren anropet och ny release ([2336861](https://github.com/kolplattformen/skolplattformen/commit/2336861a71881fdb08d3a57b0b5fbe072dc08f0e))
+* 🐛 Repaired login ([#11](https://github.com/kolplattformen/skolplattformen/issues/11)) ([83a4737](https://github.com/kolplattformen/skolplattformen/commit/83a47375945472c3c6809ed5e24ca481d2577f34))
+* 🐛 Replaced named capture group for compatibility reasons ([#112](https://github.com/kolplattformen/skolplattformen/issues/112)) ([66b23fa](https://github.com/kolplattformen/skolplattformen/commit/66b23faf4392c942467334664d32a57be72e9758))
+* 🐛 Replaces non breaking space with simple space ([#57](https://github.com/kolplattformen/skolplattformen/issues/57)) ([58d5676](https://github.com/kolplattformen/skolplattformen/commit/58d56764d3bdc10a5681d288c47b68d1cc9aa936))
+* 🐛 Return a empty array if backend returns a specific error ([1e944ad](https://github.com/kolplattformen/skolplattformen/commit/1e944adf24482fef472174d14c9d76fc9e3bf78b))
+* 🐛 semikolonviolation! ([46c6260](https://github.com/kolplattformen/skolplattformen/commit/46c62601a2a56bf9966594a2842434701213dd27))
+* 🐛 Silly stockholm stad protection ([cd19abd](https://github.com/kolplattformen/skolplattformen/commit/cd19abdd0f7f16ffc7b2a4e2de598e00e832f8c3))
+* 🐛 Tog bort radbrytning i bold ([#66](https://github.com/kolplattformen/skolplattformen/issues/66)) ([ca0117c](https://github.com/kolplattformen/skolplattformen/commit/ca0117ce64fbf1ce7eb6f476c37fc769e3df561e))
+* 🐛 Trims tag content to fix some markdown issues ([#56](https://github.com/kolplattformen/skolplattformen/issues/56)) ([f9dc391](https://github.com/kolplattformen/skolplattformen/commit/f9dc39128e1af21c4aaa23ca68cd81dcb9935448))
+* 🐛 URLSearchParams compatible with both node and RN ([#111](https://github.com/kolplattformen/skolplattformen/issues/111)) ([fd919a0](https://github.com/kolplattformen/skolplattformen/commit/fd919a0b5e961af00050e6c12a997bb6aa60d9ad))
+* 🐛 use childcontroller script for XSRF header to CreateItem ([2796875](https://github.com/kolplattformen/skolplattformen/commit/2796875fe2593d5dc8f1be573f0f27ddb3216342))
+* 🐛 Working notification url:s ([#41](https://github.com/kolplattformen/skolplattformen/issues/41)) ([3a808f9](https://github.com/kolplattformen/skolplattformen/commit/3a808f9ccd67994a615339223539fe8c5f51fc0a))
+* add date handler ([a3e0eba](https://github.com/kolplattformen/skolplattformen/commit/a3e0eba706dd855af0e06775e913000c531b9f6e))
+* correct fake data dates ([d88bfcf](https://github.com/kolplattformen/skolplattformen/commit/d88bfcf5641e4dff89d6af6709fea00cae5a4c5b))
+* handle iso date strings ([ca0a3e4](https://github.com/kolplattformen/skolplattformen/commit/ca0a3e49aca34edab2881eb38349d866928c29ab))
+* handle long dates with time ([3ba96fe](https://github.com/kolplattformen/skolplattformen/commit/3ba96feec9804cb945d9a09d709461ac4c61d902))
+* handle missing spaces in intro after certain characters ([#99](https://github.com/kolplattformen/skolplattformen/issues/99)) ([2926de3](https://github.com/kolplattformen/skolplattformen/commit/2926de31fe938cc5dd8284d47119454e4dee14a1))
+* links ([#64](https://github.com/kolplattformen/skolplattformen/issues/64)) ([905b893](https://github.com/kolplattformen/skolplattformen/commit/905b893ca735ffe9f7625d9eae18dbb2c12f1b1f))
+* parse calendar dates as utc before iso ([#100](https://github.com/kolplattformen/skolplattformen/issues/100)) ([73f6d8b](https://github.com/kolplattformen/skolplattformen/commit/73f6d8ba72bfdbb018fb564abcd4ad55bf288a3e))
+* parse intro without positive lookbehind regex ([#102](https://github.com/kolplattformen/skolplattformen/issues/102)) ([f8b3df2](https://github.com/kolplattformen/skolplattformen/commit/f8b3df2936c0eed0dec226c56cbd062272629655))
+* Translations update from Weblate ([#16](https://github.com/kolplattformen/skolplattformen/issues/16)) ([94a3883](https://github.com/kolplattformen/skolplattformen/commit/94a38833c14124c84277ca9a79cb7630226b2948))
+* use date constructor instead of luxon ([74ea878](https://github.com/kolplattformen/skolplattformen/commit/74ea878073bc72934793604b00797264ca252afa))
+* use parseDate for all date handling ([6cd92ac](https://github.com/kolplattformen/skolplattformen/commit/6cd92acbe326e6622df49832e3a46cb57e6f92a1))
+
+
+### Features
+
+* 🎸 Added .author and .imageAltText on NewsItem ([#42](https://github.com/kolplattformen/skolplattformen/issues/42)) ([6e84a63](https://github.com/kolplattformen/skolplattformen/commit/6e84a6391a9702503ceda89f1399a9c600b2315d))
+* 🎸 Added getter for logged in personal number ([#39](https://github.com/kolplattformen/skolplattformen/issues/39)) ([a860d12](https://github.com/kolplattformen/skolplattformen/commit/a860d1208c5d79f0d06034ebd993bc1f3cf2eb5e))
+* 🎸 Added language support ([#121](https://github.com/kolplattformen/skolplattformen/issues/121)) ([9dcdf78](https://github.com/kolplattformen/skolplattformen/commit/9dcdf78515a944bb48fffecc9af5072dab8fe851))
+* 🎸 Alla nyhetsbrev ([#67](https://github.com/kolplattformen/skolplattformen/issues/67)) ([f3f658f](https://github.com/kolplattformen/skolplattformen/commit/f3f658fdd33300304f9969bae7d892359859293f))
+* 🎸 API call retries and support for error reporting ([#5](https://github.com/kolplattformen/skolplattformen/issues/5)) ([9ed5df2](https://github.com/kolplattformen/skolplattformen/commit/9ed5df2e45e8d368d3d4df1c992a0901a512ff6a))
+* 🎸 Build, tag and release ([b71adc5](https://github.com/kolplattformen/skolplattformen/commit/b71adc57fbdd4ff4d6fe1b87e7afac90a9d6628c))
+* 🎸 cache busting ([5ce4ddd](https://github.com/kolplattformen/skolplattformen/commit/5ce4ddd9d04501a15ce37c9f3378e36b3f3dabfe))
+* 🎸 Cache prefixas med personnummer ([#8](https://github.com/kolplattformen/skolplattformen/issues/8)) ([fc146ea](https://github.com/kolplattformen/skolplattformen/commit/fc146ea7fc9f705b88bbc75a6cc01b6f2235bfaa))
+* 🎸 Classmates ([#14](https://github.com/kolplattformen/skolplattformen/issues/14)) ([a6ce6ea](https://github.com/kolplattformen/skolplattformen/commit/a6ce6ea9f6468ad5c1e26df4228706a1055e241a)), closes [#7](https://github.com/kolplattformen/skolplattformen/issues/7)
+* 🎸 Code cleanup, refactoring, linting and tests ([d0a0314](https://github.com/kolplattformen/skolplattformen/commit/d0a0314ae6f058c617227d28d738bff9fc85e966))
+* 🎸 Curriculum as peer dependency ([#122](https://github.com/kolplattformen/skolplattformen/issues/122)) ([e24a9b3](https://github.com/kolplattformen/skolplattformen/commit/e24a9b3c5e0d64a395e4b576975cc2b3e6832bab))
+* 🎸 Exporting all types in index ([#45](https://github.com/kolplattformen/skolplattformen/issues/45)) ([8351ef2](https://github.com/kolplattformen/skolplattformen/commit/8351ef275f1ac87da00fdeaa86a3f4e17a1e15b1))
+* 🎸 Exporting LoginStatusChecker interface ([#46](https://github.com/kolplattformen/skolplattformen/issues/46)) ([20e18e5](https://github.com/kolplattformen/skolplattformen/commit/20e18e5e23e1a1def00667a3f23e9992511a708b))
+* 🎸 Fake mode for 121212121212, 201212121212 and 1212121212 ([#35](https://github.com/kolplattformen/skolplattformen/issues/35)) ([8d264b9](https://github.com/kolplattformen/skolplattformen/commit/8d264b9787f20c2c93348f9538d1775a8b931d05))
+* 🎸 Fakedata laggar 0.2-1 sekund ([#68](https://github.com/kolplattformen/skolplattformen/issues/68)) ([018d600](https://github.com/kolplattformen/skolplattformen/commit/018d60099dffbb57c387367a31a091620f5132a7))
+* 🎸 Fallback language ([#7](https://github.com/kolplattformen/skolplattformen/issues/7)) ([e944468](https://github.com/kolplattformen/skolplattformen/commit/e94446873429438b79a81542caf8f4f4f1882ce0))
+* 🎸 First implementation ([e5438b0](https://github.com/kolplattformen/skolplattformen/commit/e5438b0f264afb564efec7aca46adad0db6bd6e2))
+* 🎸 First release ([d37f3db](https://github.com/kolplattformen/skolplattformen/commit/d37f3db3e8df421bb1ed8848ab63220a9b461b24))
+* 🎸 Forcing release ([d4151fa](https://github.com/kolplattformen/skolplattformen/commit/d4151fa26faa3017d5c36ca3eef4966db6d7267b))
+* 🎸 getSessionCookie and removed News object ([#24](https://github.com/kolplattformen/skolplattformen/issues/24)) ([91ba683](https://github.com/kolplattformen/skolplattformen/commit/91ba6833b456dd446948c886c80768d2af360a25)), closes [#22](https://github.com/kolplattformen/skolplattformen/issues/22) [#23](https://github.com/kolplattformen/skolplattformen/issues/23)
+* 🎸 getUser ([#19](https://github.com/kolplattformen/skolplattformen/issues/19)) ([39b62b7](https://github.com/kolplattformen/skolplattformen/commit/39b62b7b371b0990e9c4594603e8e95219234dd5)), closes [#9](https://github.com/kolplattformen/skolplattformen/issues/9)
+* 🎸 Hämta lektionsschema ([#110](https://github.com/kolplattformen/skolplattformen/issues/110)) ([c288449](https://github.com/kolplattformen/skolplattformen/commit/c2884497bf66fccbae79883e3e1d9470d7c9fc55))
+* 🎸 Image ([#21](https://github.com/kolplattformen/skolplattformen/issues/21)) ([2ad7523](https://github.com/kolplattformen/skolplattformen/commit/2ad7523a1ded17bbb20b491cd54cd9c960c825a3)), closes [#10](https://github.com/kolplattformen/skolplattformen/issues/10)
+* 🎸 It now handles comments ([065e0e9](https://github.com/kolplattformen/skolplattformen/commit/065e0e968276bc385ecec314a5577a5be44bfaf6))
+* 🎸 Loads schedule ([#16](https://github.com/kolplattformen/skolplattformen/issues/16)) ([53d42de](https://github.com/kolplattformen/skolplattformen/commit/53d42de62cae311e28decf50591e521128c9bfcb)), closes [#13](https://github.com/kolplattformen/skolplattformen/issues/13) [#8](https://github.com/kolplattformen/skolplattformen/issues/8)
+* 🎸 Made User properties optional for hook convenience ([#31](https://github.com/kolplattformen/skolplattformen/issues/31)) ([0e0e996](https://github.com/kolplattformen/skolplattformen/commit/0e0e9965892e69819e9b49dfcdf2afdddacccb47))
+* 🎸 Misc codes (Lunch, Prandium, MTID) ([59e350b](https://github.com/kolplattformen/skolplattformen/commit/59e350b6ab6d1164d64b84428226a0c6e078c622))
+* 🎸 Multilang support for useTimetable ([#14](https://github.com/kolplattformen/skolplattformen/issues/14)) ([be6c9d1](https://github.com/kolplattformen/skolplattformen/commit/be6c9d1302a8f098bf1d57058285c90745ca9626))
+* 🎸 Names from curriculum ([#116](https://github.com/kolplattformen/skolplattformen/issues/116)) ([504503f](https://github.com/kolplattformen/skolplattformen/commit/504503f7a0c243b5d24f1784ad83af2e9d01feee))
+* 🎸 New properties on NewsItem and updated fake data ([#44](https://github.com/kolplattformen/skolplattformen/issues/44)) ([dea899b](https://github.com/kolplattformen/skolplattformen/commit/dea899bd17d43bf95936065bb92a523dd3da79f2))
+* 🎸 News are sorted, desc, by modified date ([#147](https://github.com/kolplattformen/skolplattformen/issues/147)) ([a4b7b7f](https://github.com/kolplattformen/skolplattformen/commit/a4b7b7f6a942e2bdedd82c50e16f5336bb6fc1ec))
+* 🎸 News images that do not require login ([#43](https://github.com/kolplattformen/skolplattformen/issues/43)) ([5daf186](https://github.com/kolplattformen/skolplattformen/commit/5daf186d5cd6ff7084ea7bbc38d9586c1ec9b59e))
+* 🎸 Notifications ([#20](https://github.com/kolplattformen/skolplattformen/issues/20)) ([348e437](https://github.com/kolplattformen/skolplattformen/commit/348e43778df7e7336148b327a0ce2363bca05fa4)), closes [#11](https://github.com/kolplattformen/skolplattformen/issues/11)
+* 🎸 Notifications sorted by modified, then created date ([#151](https://github.com/kolplattformen/skolplattformen/issues/151)) ([91f63e8](https://github.com/kolplattformen/skolplattformen/commit/91f63e8d2ac060692090d8f75379a3a7c6a1a074))
+* 🎸 Polish ([#9](https://github.com/kolplattformen/skolplattformen/issues/9)) ([18c8126](https://github.com/kolplattformen/skolplattformen/commit/18c81264a08123526989d33ee1dd1ade08c38d8d))
+* 🎸 Possibly first working version ([0e4acba](https://github.com/kolplattformen/skolplattformen/commit/0e4acba776558aa25f00347ac38cdd2d873da657))
+* 🎸 Remove all obsolete login obstacles ([#146](https://github.com/kolplattformen/skolplattformen/issues/146)) ([befb073](https://github.com/kolplattformen/skolplattformen/commit/befb073a322823dfad2b29e8ab03488b68f2a16c))
+* 🎸 Remove required personal number in route ([#118](https://github.com/kolplattformen/skolplattformen/issues/118)) ([c3b4b15](https://github.com/kolplattformen/skolplattformen/commit/c3b4b153c34de34d85681f41dbdfd0c1f5d356bd))
+* 🎸 Removed getImage() and added .fullImageUrl to NewsItem ([#33](https://github.com/kolplattformen/skolplattformen/issues/33)) ([5c3929d](https://github.com/kolplattformen/skolplattformen/commit/5c3929d9d171f720b60369b4f5fe105da83af6b0))
+* 🎸 Replaced Moment with Luxon ([#30](https://github.com/kolplattformen/skolplattformen/issues/30)) ([e41f0bf](https://github.com/kolplattformen/skolplattformen/commit/e41f0bf4357ddb762667c6837d54726addc8fd44))
+* 🎸 Släpp sargen - nu kör vi ([#60](https://github.com/kolplattformen/skolplattformen/issues/60)) ([c5e9992](https://github.com/kolplattformen/skolplattformen/commit/c5e9992f9ab204799aad5d040b26d62e33703aff))
+* 🎸 Switched to Markdown Extra converter ([#58](https://github.com/kolplattformen/skolplattformen/issues/58)) ([3b7b067](https://github.com/kolplattformen/skolplattformen/commit/3b7b0677a457673d225511c43ca00add73498930))
+* 🎸 Timetables ([#12](https://github.com/kolplattformen/skolplattformen/issues/12)) ([2ae212d](https://github.com/kolplattformen/skolplattformen/commit/2ae212d46a7c8c333101f39e76435721c8d0d00e))
+* 🎸 Updated curriculum and fake data with new codes ([#117](https://github.com/kolplattformen/skolplattformen/issues/117)) ([0a02ffa](https://github.com/kolplattformen/skolplattformen/commit/0a02ffa04d7d7e6610bf2f2fffa83a683fc23726))
+* 🎸 useNewsDetails(child, news) ([5d4f751](https://github.com/kolplattformen/skolplattformen/commit/5d4f7515cd7af66e5a192520bf7d96aab72e8bf5))
+* add newsItemDetails ([1826b80](https://github.com/kolplattformen/skolplattformen/commit/1826b80d4bd2ee97fedb1f04f70a95bb478878de))
+* call newsItemDetails to get details for a news item. Resolves [#28](https://github.com/kolplattformen/skolplattformen/issues/28) ([5dcc42e](https://github.com/kolplattformen/skolplattformen/commit/5dcc42eeac0b4acda11515271b63aeb42e3773d9))
+* Improve menu ([#109](https://github.com/kolplattformen/skolplattformen/issues/109)) ([9c4fcb2](https://github.com/kolplattformen/skolplattformen/commit/9c4fcb2d251d71ec076e3b1725ae74b497535d66))
+* Ombyggd parsning av nyhetsbrev ([#65](https://github.com/kolplattformen/skolplattformen/issues/65)) ([a5dfb70](https://github.com/kolplattformen/skolplattformen/commit/a5dfb704f4c7428b148cd26f94eceb9567bfb35e))
+* update typings for ScheduleItem ([9c87535](https://github.com/kolplattformen/skolplattformen/commit/9c87535c5bd8e1c9ed8e66d03c13cb6dc8cce8fb))
+
+
+* Rebuilt session handling and login (#78) ([c62dab9](https://github.com/kolplattformen/skolplattformen/commit/c62dab9e2e9be4b208f0cb2fc9bb6253beb2b403)), closes [#78](https://github.com/kolplattformen/skolplattformen/issues/78)
 
 
 ### BREAKING CHANGES
@@ -483,902 +483,902 @@ potentially `undefined`
 luxon.DateTime)
 * 🧨 Call signature of getNews changed
 
-# [1.48.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.47.2...v1.48.0) (2021-10-01)
+# [1.48.0](https://github.com/kolplattformen/skolplattformen/compare/v1.47.2...v1.48.0) (2021-10-01)
 
 
 ### Features
 
-* 🎸 Notifications use modified, then created date ([a655bbc](https://github.com/kolplattformen/skolplattformen-app/commit/a655bbc590b2ac8016bc4ccb73030aa68ce1e891))
+* 🎸 Notifications use modified, then created date ([a655bbc](https://github.com/kolplattformen/skolplattformen/commit/a655bbc590b2ac8016bc4ccb73030aa68ce1e891))
 
-## [1.47.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.47.1...v1.47.2) (2021-09-30)
-
-
-### Bug Fixes
-
-* 🐛 Hämta alla aviseringar och sortera på senast ändrad ([71cb230](https://github.com/kolplattformen/skolplattformen-app/commit/71cb230b92901bf6c15f81126ed51a00c79afc4f))
-* 🐛 Tog bort headerLargeTitle från navigationComponent ([73019af](https://github.com/kolplattformen/skolplattformen-app/commit/73019af8f4b2321fbba5c8c4d996fdbda1086c5d))
-
-## [1.47.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.47.0...v1.47.1) (2021-09-29)
+## [1.47.2](https://github.com/kolplattformen/skolplattformen/compare/v1.47.1...v1.47.2) (2021-09-30)
 
 
 ### Bug Fixes
 
-* 🐛 Begränsa höjden på schemat ([#495](https://github.com/kolplattformen/skolplattformen-app/issues/495)) ([5c81ad3](https://github.com/kolplattformen/skolplattformen-app/commit/5c81ad3145764c2012f457eaa380d5f2885aaf1b))
+* 🐛 Hämta alla aviseringar och sortera på senast ändrad ([71cb230](https://github.com/kolplattformen/skolplattformen/commit/71cb230b92901bf6c15f81126ed51a00c79afc4f))
+* 🐛 Tog bort headerLargeTitle från navigationComponent ([73019af](https://github.com/kolplattformen/skolplattformen/commit/73019af8f4b2321fbba5c8c4d996fdbda1086c5d))
 
-# [1.47.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.46.2...v1.47.0) (2021-09-29)
+## [1.47.1](https://github.com/kolplattformen/skolplattformen/compare/v1.47.0...v1.47.1) (2021-09-29)
+
+
+### Bug Fixes
+
+* 🐛 Begränsa höjden på schemat ([#495](https://github.com/kolplattformen/skolplattformen/issues/495)) ([5c81ad3](https://github.com/kolplattformen/skolplattformen/commit/5c81ad3145764c2012f457eaa380d5f2885aaf1b))
+
+# [1.47.0](https://github.com/kolplattformen/skolplattformen/compare/v1.46.2...v1.47.0) (2021-09-29)
 
 
 ### Features
 
-* 🎸 add settings screen ([#492](https://github.com/kolplattformen/skolplattformen-app/issues/492)) ([3b307d2](https://github.com/kolplattformen/skolplattformen-app/commit/3b307d25b3218764d559c4e80e196f7758ca0244))
+* 🎸 add settings screen ([#492](https://github.com/kolplattformen/skolplattformen/issues/492)) ([3b307d2](https://github.com/kolplattformen/skolplattformen/commit/3b307d25b3218764d559c4e80e196f7758ca0244))
 
-## [1.46.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.46.1...v1.46.2) (2021-09-29)
-
-
-### Bug Fixes
-
-* 🐛 Correct font name so the font shows on Android ([#493](https://github.com/kolplattformen/skolplattformen-app/issues/493)) ([fd1ff0d](https://github.com/kolplattformen/skolplattformen-app/commit/fd1ff0dc718a4eaf9aacf3beccdfb0f8b3ba8117))
-
-## [1.46.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.46.0...v1.46.1) (2021-09-23)
+## [1.46.2](https://github.com/kolplattformen/skolplattformen/compare/v1.46.1...v1.46.2) (2021-09-29)
 
 
 ### Bug Fixes
 
-* 🐛 Bumped embedded to 5.3.2 ([4522298](https://github.com/kolplattformen/skolplattformen-app/commit/4522298d154d686a2840c05481ac53b2046b2b8e))
+* 🐛 Correct font name so the font shows on Android ([#493](https://github.com/kolplattformen/skolplattformen/issues/493)) ([fd1ff0d](https://github.com/kolplattformen/skolplattformen/commit/fd1ff0dc718a4eaf9aacf3beccdfb0f8b3ba8117))
 
-# [1.46.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.45.1...v1.46.0) (2021-09-23)
+## [1.46.1](https://github.com/kolplattformen/skolplattformen/compare/v1.46.0...v1.46.1) (2021-09-23)
+
+
+### Bug Fixes
+
+* 🐛 Bumped embedded to 5.3.2 ([4522298](https://github.com/kolplattformen/skolplattformen/commit/4522298d154d686a2840c05481ac53b2046b2b8e))
+
+# [1.46.0](https://github.com/kolplattformen/skolplattformen/compare/v1.45.1...v1.46.0) (2021-09-23)
 
 
 ### Features
 
-* 🎸 Use custom async storage ([#461](https://github.com/kolplattformen/skolplattformen-app/issues/461)) ([98f7c04](https://github.com/kolplattformen/skolplattformen-app/commit/98f7c04f1c1b88d621440c6190cf1223112fa03b))
+* 🎸 Use custom async storage ([#461](https://github.com/kolplattformen/skolplattformen/issues/461)) ([98f7c04](https://github.com/kolplattformen/skolplattformen/commit/98f7c04f1c1b88d621440c6190cf1223112fa03b))
 
-## [1.45.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.45.0...v1.45.1) (2021-09-22)
+## [1.45.1](https://github.com/kolplattformen/skolplattformen/compare/v1.45.0...v1.45.1) (2021-09-22)
 
 
 ### Bug Fixes
 
-* 🐛 Fixes crash in 2.0.1 (RN 0651 upgrade issue) ([#481](https://github.com/kolplattformen/skolplattformen-app/issues/481)) ([0f893b9](https://github.com/kolplattformen/skolplattformen-app/commit/0f893b9b6d6fd6e53ecd0cad79ef00fc9dbd68fc))
+* 🐛 Fixes crash in 2.0.1 (RN 0651 upgrade issue) ([#481](https://github.com/kolplattformen/skolplattformen/issues/481)) ([0f893b9](https://github.com/kolplattformen/skolplattformen/commit/0f893b9b6d6fd6e53ecd0cad79ef00fc9dbd68fc))
 
-# [1.45.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.44.0...v1.45.0) (2021-09-18)
+# [1.45.0](https://github.com/kolplattformen/skolplattformen/compare/v1.44.0...v1.45.0) (2021-09-18)
 
 
 ### Features
 
-* 🎸 Fler språk i schemat (uppd. curriculum) ([#476](https://github.com/kolplattformen/skolplattformen-app/issues/476)) ([6a30053](https://github.com/kolplattformen/skolplattformen-app/commit/6a3005330ccfffdc67c646ba212160cf6c87e6e2))
+* 🎸 Fler språk i schemat (uppd. curriculum) ([#476](https://github.com/kolplattformen/skolplattformen/issues/476)) ([6a30053](https://github.com/kolplattformen/skolplattformen/commit/6a3005330ccfffdc67c646ba212160cf6c87e6e2))
 
-# [1.44.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.43.2...v1.44.0) (2021-09-18)
-
-
-### Features
-
-* 🎸 Changed newsListItem display date to modified ([c1da658](https://github.com/kolplattformen/skolplattformen-app/commit/c1da6583881e6813eb68118fc41706fc3b65be9e))
-* 🎸 Modified used for child overview as well ([0ad8bfe](https://github.com/kolplattformen/skolplattformen-app/commit/0ad8bfe15c544f2fe34a7d7b2bc4284dec70a6b3))
-* 🎸 Updated embedded for correct sorting ([9efef8d](https://github.com/kolplattformen/skolplattformen-app/commit/9efef8dad9e44e80422feb94ff7c68b22f3be51f))
-
-## [1.43.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.43.1...v1.43.2) (2021-09-16)
-
-
-### Bug Fixes
-
-* 🐛 Småfixar i schemat ([2c770c0](https://github.com/kolplattformen/skolplattformen-app/commit/2c770c08fb6e8adea558ec0af1be77978af843e0))
-
-## [1.43.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.43.0...v1.43.1) (2021-09-16)
-
-
-### Bug Fixes
-
-* 🐛 Översättningar på menytabbarna ([#471](https://github.com/kolplattformen/skolplattformen-app/issues/471)) ([b7a732d](https://github.com/kolplattformen/skolplattformen-app/commit/b7a732d21b1a84c3a3a26b7eb680937384de4c93))
-
-# [1.43.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.42.2...v1.43.0) (2021-09-16)
+# [1.44.0](https://github.com/kolplattformen/skolplattformen/compare/v1.43.2...v1.44.0) (2021-09-18)
 
 
 ### Features
 
-* 🎸 Den nygamla klasslistan ([#462](https://github.com/kolplattformen/skolplattformen-app/issues/462)) ([f0d05a5](https://github.com/kolplattformen/skolplattformen-app/commit/f0d05a50000a2958db9c0abb9bd9d9d2546414e8)), closes [#441](https://github.com/kolplattformen/skolplattformen-app/issues/441)
+* 🎸 Changed newsListItem display date to modified ([c1da658](https://github.com/kolplattformen/skolplattformen/commit/c1da6583881e6813eb68118fc41706fc3b65be9e))
+* 🎸 Modified used for child overview as well ([0ad8bfe](https://github.com/kolplattformen/skolplattformen/commit/0ad8bfe15c544f2fe34a7d7b2bc4284dec70a6b3))
+* 🎸 Updated embedded for correct sorting ([9efef8d](https://github.com/kolplattformen/skolplattformen/commit/9efef8dad9e44e80422feb94ff7c68b22f3be51f))
 
-## [1.42.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.42.1...v1.42.2) (2021-09-15)
-
-
-### Bug Fixes
-
-* 🐛 Välja språk på Android var trasigt ([#467](https://github.com/kolplattformen/skolplattformen-app/issues/467)) ([d431d68](https://github.com/kolplattformen/skolplattformen-app/commit/d431d68f5cee6f3550ba7937aa9d177ab083baba))
-
-## [1.42.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.42.0...v1.42.1) (2021-09-14)
+## [1.43.2](https://github.com/kolplattformen/skolplattformen/compare/v1.43.1...v1.43.2) (2021-09-16)
 
 
 ### Bug Fixes
 
-* 🐛 Fixes long navigation names in tab bar ([fe51923](https://github.com/kolplattformen/skolplattformen-app/commit/fe5192324961f0c2a941c4fa182637dbf9199c0e))
-* decrease font weight to 500 ([69ff3ff](https://github.com/kolplattformen/skolplattformen-app/commit/69ff3ff0e1c65747a7aa6ef469187f06e2b0274c))
-* fontSize on tabBarLabel decreased ([36bc627](https://github.com/kolplattformen/skolplattformen-app/commit/36bc62752a97b62597f3a368152fd86e5a98212f))
+* 🐛 Småfixar i schemat ([2c770c0](https://github.com/kolplattformen/skolplattformen/commit/2c770c08fb6e8adea558ec0af1be77978af843e0))
 
-# [1.42.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.41.0...v1.42.0) (2021-09-14)
+## [1.43.1](https://github.com/kolplattformen/skolplattformen/compare/v1.43.0...v1.43.1) (2021-09-16)
 
 
 ### Bug Fixes
 
-* update colors to reach AAA ([0140984](https://github.com/kolplattformen/skolplattformen-app/commit/0140984918e13f63b6302dc34d3ce163b3b697df))
+* 🐛 Översättningar på menytabbarna ([#471](https://github.com/kolplattformen/skolplattformen/issues/471)) ([b7a732d](https://github.com/kolplattformen/skolplattformen/commit/b7a732d21b1a84c3a3a26b7eb680937384de4c93))
+
+# [1.43.0](https://github.com/kolplattformen/skolplattformen/compare/v1.42.2...v1.43.0) (2021-09-16)
 
 
 ### Features
 
-* 🎸 Fixes status page and bump embedded ([7b65652](https://github.com/kolplattformen/skolplattformen-app/commit/7b6565296e3895c13384af571e2c60bf0ee4e24a))
+* 🎸 Den nygamla klasslistan ([#462](https://github.com/kolplattformen/skolplattformen/issues/462)) ([f0d05a5](https://github.com/kolplattformen/skolplattformen/commit/f0d05a50000a2958db9c0abb9bd9d9d2546414e8)), closes [#441](https://github.com/kolplattformen/skolplattformen/issues/441)
 
-# [1.41.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.40.1...v1.41.0) (2021-09-13)
+## [1.42.2](https://github.com/kolplattformen/skolplattformen/compare/v1.42.1...v1.42.2) (2021-09-15)
+
+
+### Bug Fixes
+
+* 🐛 Välja språk på Android var trasigt ([#467](https://github.com/kolplattformen/skolplattformen/issues/467)) ([d431d68](https://github.com/kolplattformen/skolplattformen/commit/d431d68f5cee6f3550ba7937aa9d177ab083baba))
+
+## [1.42.1](https://github.com/kolplattformen/skolplattformen/compare/v1.42.0...v1.42.1) (2021-09-14)
+
+
+### Bug Fixes
+
+* 🐛 Fixes long navigation names in tab bar ([fe51923](https://github.com/kolplattformen/skolplattformen/commit/fe5192324961f0c2a941c4fa182637dbf9199c0e))
+* decrease font weight to 500 ([69ff3ff](https://github.com/kolplattformen/skolplattformen/commit/69ff3ff0e1c65747a7aa6ef469187f06e2b0274c))
+* fontSize on tabBarLabel decreased ([36bc627](https://github.com/kolplattformen/skolplattformen/commit/36bc62752a97b62597f3a368152fd86e5a98212f))
+
+# [1.42.0](https://github.com/kolplattformen/skolplattformen/compare/v1.41.0...v1.42.0) (2021-09-14)
+
+
+### Bug Fixes
+
+* update colors to reach AAA ([0140984](https://github.com/kolplattformen/skolplattformen/commit/0140984918e13f63b6302dc34d3ce163b3b697df))
 
 
 ### Features
 
-* 🎸 release 2.0.0 for Android ([0dcb983](https://github.com/kolplattformen/skolplattformen-app/commit/0dcb98312faa6bc81c264e0f8e1ca810bc72b0c3))
+* 🎸 Fixes status page and bump embedded ([7b65652](https://github.com/kolplattformen/skolplattformen/commit/7b6565296e3895c13384af571e2c60bf0ee4e24a))
 
-## [1.40.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.40.0...v1.40.1) (2021-09-12)
-
-
-### Bug Fixes
-
-* 🐛 Bump embedded-api to 5.2.0 ([9f00ba4](https://github.com/kolplattformen/skolplattformen-app/commit/9f00ba4929226c8e97528d33da4ee0aa0e5dc87e))
-
-# [1.40.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.39.1...v1.40.0) (2021-09-09)
-
-
-### Bug Fixes
-
-* 🐛 Added hitslop to language button to increase touch area ([#449](https://github.com/kolplattformen/skolplattformen-app/issues/449)) ([26a85da](https://github.com/kolplattformen/skolplattformen-app/commit/26a85dae39e1a7258a2262ac1b195bf9b74535e7)), closes [#436](https://github.com/kolplattformen/skolplattformen-app/issues/436)
-* 🐛 Changed to "Öppna skolplattformen" on startpage ([#447](https://github.com/kolplattformen/skolplattformen-app/issues/447)) ([29be7de](https://github.com/kolplattformen/skolplattformen-app/commit/29be7debc2367fd0c6f3d6cebc8c53b01c250c9b)), closes [#433](https://github.com/kolplattformen/skolplattformen-app/issues/433)
-* 🐛 fix missing "app" target in projet file ([4e91bb5](https://github.com/kolplattformen/skolplattformen-app/commit/4e91bb57cdcaf0ff09248cef9b77a8610cb3959c))
-* adjust margins and typography on start page ([aea0b52](https://github.com/kolplattformen/skolplattformen-app/commit/aea0b5264b61d41a96d7ce18a3fb6cb7d75c1cb9))
-* fix tests ([485db25](https://github.com/kolplattformen/skolplattformen-app/commit/485db2580793d6d53f188d6b47c6abec0d1f6647))
-* hide start-end if we have no schedule ([616362d](https://github.com/kolplattformen/skolplattformen-app/commit/616362d14b86ea13d989376d6495565d7d24389f))
-* linter ([62e278a](https://github.com/kolplattformen/skolplattformen-app/commit/62e278a44bff74d939994ba7ab47013b0de37fe0))
-* Öppna skolplattformen på alla språk. Closes [#333](https://github.com/kolplattformen/skolplattformen-app/issues/333) ([5cda041](https://github.com/kolplattformen/skolplattformen-app/commit/5cda041cdab78bcbe1de6c4d5445d32359b6b76b))
+# [1.41.0](https://github.com/kolplattformen/skolplattformen/compare/v1.40.1...v1.41.0) (2021-09-13)
 
 
 ### Features
 
-* add lunch to daily schedule ([76c7108](https://github.com/kolplattformen/skolplattformen-app/commit/76c7108b966c8693102696b98ec7913f55f2382a))
-* add lunch to schedule ([03eab44](https://github.com/kolplattformen/skolplattformen-app/commit/03eab44fc918ff5aabcabf9d96ca0640c8eeb4e8))
-* day summary on front page ([b82f744](https://github.com/kolplattformen/skolplattformen-app/commit/b82f744567bafe0e7804625ca3101965cdc12fe0))
+* 🎸 release 2.0.0 for Android ([0dcb983](https://github.com/kolplattformen/skolplattformen/commit/0dcb98312faa6bc81c264e0f8e1ca810bc72b0c3))
 
-## [1.39.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.39.0...v1.39.1) (2021-09-08)
+## [1.40.1](https://github.com/kolplattformen/skolplattformen/compare/v1.40.0...v1.40.1) (2021-09-12)
 
 
 ### Bug Fixes
 
-* 🐛 Bump embedded-api to 5.1.4 ([0d4591e](https://github.com/kolplattformen/skolplattformen-app/commit/0d4591ece89bc4ca1657406dd5220574cdd2117a))
+* 🐛 Bump embedded-api to 5.2.0 ([9f00ba4](https://github.com/kolplattformen/skolplattformen/commit/9f00ba4929226c8e97528d33da4ee0aa0e5dc87e))
 
-# [1.39.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.38.1...v1.39.0) (2021-08-19)
+# [1.40.0](https://github.com/kolplattformen/skolplattformen/compare/v1.39.1...v1.40.0) (2021-09-09)
+
+
+### Bug Fixes
+
+* 🐛 Added hitslop to language button to increase touch area ([#449](https://github.com/kolplattformen/skolplattformen/issues/449)) ([26a85da](https://github.com/kolplattformen/skolplattformen/commit/26a85dae39e1a7258a2262ac1b195bf9b74535e7)), closes [#436](https://github.com/kolplattformen/skolplattformen/issues/436)
+* 🐛 Changed to "Öppna skolplattformen" on startpage ([#447](https://github.com/kolplattformen/skolplattformen/issues/447)) ([29be7de](https://github.com/kolplattformen/skolplattformen/commit/29be7debc2367fd0c6f3d6cebc8c53b01c250c9b)), closes [#433](https://github.com/kolplattformen/skolplattformen/issues/433)
+* 🐛 fix missing "app" target in projet file ([4e91bb5](https://github.com/kolplattformen/skolplattformen/commit/4e91bb57cdcaf0ff09248cef9b77a8610cb3959c))
+* adjust margins and typography on start page ([aea0b52](https://github.com/kolplattformen/skolplattformen/commit/aea0b5264b61d41a96d7ce18a3fb6cb7d75c1cb9))
+* fix tests ([485db25](https://github.com/kolplattformen/skolplattformen/commit/485db2580793d6d53f188d6b47c6abec0d1f6647))
+* hide start-end if we have no schedule ([616362d](https://github.com/kolplattformen/skolplattformen/commit/616362d14b86ea13d989376d6495565d7d24389f))
+* linter ([62e278a](https://github.com/kolplattformen/skolplattformen/commit/62e278a44bff74d939994ba7ab47013b0de37fe0))
+* Öppna skolplattformen på alla språk. Closes [#333](https://github.com/kolplattformen/skolplattformen/issues/333) ([5cda041](https://github.com/kolplattformen/skolplattformen/commit/5cda041cdab78bcbe1de6c4d5445d32359b6b76b))
 
 
 ### Features
 
-* add police report protocol ([77b3c6b](https://github.com/kolplattformen/skolplattformen-app/commit/77b3c6b0848578a3acf0a119450e5ba3396b93fe))
+* add lunch to daily schedule ([76c7108](https://github.com/kolplattformen/skolplattformen/commit/76c7108b966c8693102696b98ec7913f55f2382a))
+* add lunch to schedule ([03eab44](https://github.com/kolplattformen/skolplattformen/commit/03eab44fc918ff5aabcabf9d96ca0640c8eeb4e8))
+* day summary on front page ([b82f744](https://github.com/kolplattformen/skolplattformen/commit/b82f744567bafe0e7804625ca3101965cdc12fe0))
 
-## [1.38.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.38.0...v1.38.1) (2021-08-17)
-
-
-### Bug Fixes
-
-* 🐛 Ta bort avbryt från listan vid login ([#443](https://github.com/kolplattformen/skolplattformen-app/issues/443)) ([6f68751](https://github.com/kolplattformen/skolplattformen-app/commit/6f68751e1029d0b83f4080052c44817dcd0fa8f5))
-
-# [1.38.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.37.0...v1.38.0) (2021-08-16)
+## [1.39.1](https://github.com/kolplattformen/skolplattformen/compare/v1.39.0...v1.39.1) (2021-09-08)
 
 
 ### Bug Fixes
 
-* bugfix, must call the damn function ([b6c7f78](https://github.com/kolplattformen/skolplattformen-app/commit/b6c7f7853b890b054a1f5ae54b69c1e1e006bc4f))
-* flash was in js, now ts ([5e39618](https://github.com/kolplattformen/skolplattformen-app/commit/5e39618e888449f06a1bb04771ad30af87012997))
-* linting ([1877cdd](https://github.com/kolplattformen/skolplattformen-app/commit/1877cdd594f0f6687f68ed58b5674bbac4d766c9))
-* remove flash msg for now ([f98b215](https://github.com/kolplattformen/skolplattformen-app/commit/f98b2154dc344b904fd29f4ab2bc365094f13994))
+* 🐛 Bump embedded-api to 5.1.4 ([0d4591e](https://github.com/kolplattformen/skolplattformen/commit/0d4591ece89bc4ca1657406dd5220574cdd2117a))
+
+# [1.39.0](https://github.com/kolplattformen/skolplattformen/compare/v1.38.1...v1.39.0) (2021-08-19)
 
 
 ### Features
 
-* automatic sorting on dates ([b911ae8](https://github.com/kolplattformen/skolplattformen-app/commit/b911ae8c8482f1817f3f54c5db135bfa33ac0885))
-* handle timeouts, throttling, ratelimit etc from google ([a67ee60](https://github.com/kolplattformen/skolplattformen-app/commit/a67ee60f027032c4141994a1ae0fbc5bb5bb06da))
-* load timeline dynamically from Google Sheet ([c53a8c0](https://github.com/kolplattformen/skolplattformen-app/commit/c53a8c0bb2181591e470cf6e38ef0a343d6f0167))
-* updated history ([9fa7d10](https://github.com/kolplattformen/skolplattformen-app/commit/9fa7d10bb1e1822a327e15cb773574c988997094))
-* updated history with events up to July ([#423](https://github.com/kolplattformen/skolplattformen-app/issues/423)) ([62c3f2a](https://github.com/kolplattformen/skolplattformen-app/commit/62c3f2a97f1c118f4bc1eed1b4bdc82ab13a907f))
+* add police report protocol ([77b3c6b](https://github.com/kolplattformen/skolplattformen/commit/77b3c6b0848578a3acf0a119450e5ba3396b93fe))
 
-# [1.37.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.36.4...v1.37.0) (2021-08-16)
+## [1.38.1](https://github.com/kolplattformen/skolplattformen/compare/v1.38.0...v1.38.1) (2021-08-17)
 
 
 ### Bug Fixes
 
-* 🐛 dark mode-färgerna tillbaka ([49328b4](https://github.com/kolplattformen/skolplattformen-app/commit/49328b44f962517910a2e143ddf51cdc083a2d5c))
+* 🐛 Ta bort avbryt från listan vid login ([#443](https://github.com/kolplattformen/skolplattformen/issues/443)) ([6f68751](https://github.com/kolplattformen/skolplattformen/commit/6f68751e1029d0b83f4080052c44817dcd0fa8f5))
+
+# [1.38.0](https://github.com/kolplattformen/skolplattformen/compare/v1.37.0...v1.38.0) (2021-08-16)
+
+
+### Bug Fixes
+
+* bugfix, must call the damn function ([b6c7f78](https://github.com/kolplattformen/skolplattformen/commit/b6c7f7853b890b054a1f5ae54b69c1e1e006bc4f))
+* flash was in js, now ts ([5e39618](https://github.com/kolplattformen/skolplattformen/commit/5e39618e888449f06a1bb04771ad30af87012997))
+* linting ([1877cdd](https://github.com/kolplattformen/skolplattformen/commit/1877cdd594f0f6687f68ed58b5674bbac4d766c9))
+* remove flash msg for now ([f98b215](https://github.com/kolplattformen/skolplattformen/commit/f98b2154dc344b904fd29f4ab2bc365094f13994))
 
 
 ### Features
 
-* Add custom Poppins typeface ([67a8aca](https://github.com/kolplattformen/skolplattformen-app/commit/67a8aca9e403ca98fefa8244c205a4cec8669f6a))
-* added day summary on front page ([1917b7e](https://github.com/kolplattformen/skolplattformen-app/commit/1917b7e2d425b0c40308480668b916156dd3e24a))
-* login screen and move logout button ([fa7b103](https://github.com/kolplattformen/skolplattformen-app/commit/fa7b10318fdf58ad1e2ef1238bae37c65ba301d5))
-* new colors ([c178f9c](https://github.com/kolplattformen/skolplattformen-app/commit/c178f9c3b4cd0ae9558df68bb51db48f33537e93))
+* automatic sorting on dates ([b911ae8](https://github.com/kolplattformen/skolplattformen/commit/b911ae8c8482f1817f3f54c5db135bfa33ac0885))
+* handle timeouts, throttling, ratelimit etc from google ([a67ee60](https://github.com/kolplattformen/skolplattformen/commit/a67ee60f027032c4141994a1ae0fbc5bb5bb06da))
+* load timeline dynamically from Google Sheet ([c53a8c0](https://github.com/kolplattformen/skolplattformen/commit/c53a8c0bb2181591e470cf6e38ef0a343d6f0167))
+* updated history ([9fa7d10](https://github.com/kolplattformen/skolplattformen/commit/9fa7d10bb1e1822a327e15cb773574c988997094))
+* updated history with events up to July ([#423](https://github.com/kolplattformen/skolplattformen/issues/423)) ([62c3f2a](https://github.com/kolplattformen/skolplattformen/commit/62c3f2a97f1c118f4bc1eed1b4bdc82ab13a907f))
 
-## [1.36.4](https://github.com/kolplattformen/skolplattformen-app/compare/v1.36.3...v1.36.4) (2021-05-28)
-
-
-### Bug Fixes
-
-* 🐛 Kalender - text blir avklippt ([#410](https://github.com/kolplattformen/skolplattformen-app/issues/410)) ([377d468](https://github.com/kolplattformen/skolplattformen-app/commit/377d4684e4b1ef51647b3adcec9dadccbbbc2a76)), closes [#409](https://github.com/kolplattformen/skolplattformen-app/issues/409)
-
-## [1.36.3](https://github.com/kolplattformen/skolplattformen-app/compare/v1.36.2...v1.36.3) (2021-05-26)
+# [1.37.0](https://github.com/kolplattformen/skolplattformen/compare/v1.36.4...v1.37.0) (2021-08-16)
 
 
 ### Bug Fixes
 
-* 🐛 add a11y properties for childListItems ([db8434d](https://github.com/kolplattformen/skolplattformen-app/commit/db8434d7f33b404c2616a69714acc64c1a67d08e)), closes [#354](https://github.com/kolplattformen/skolplattformen-app/issues/354)
-
-## [1.36.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.36.1...v1.36.2) (2021-05-25)
-
-
-### Bug Fixes
-
-* 🐛 knapparna i childListItem pekar rätt igen ([#407](https://github.com/kolplattformen/skolplattformen-app/issues/407)) ([458daf6](https://github.com/kolplattformen/skolplattformen-app/commit/458daf6c67c26134dfd27a8a8c0fcef32daf7a45))
-
-## [1.36.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.36.0...v1.36.1) (2021-05-25)
-
-
-### Bug Fixes
-
-* 🐛 use modal for login method picker. Fixes [#404](https://github.com/kolplattformen/skolplattformen-app/issues/404) ([bf472fb](https://github.com/kolplattformen/skolplattformen-app/commit/bf472fb94389cdb7164e7d6fa042235722c7777e))
-
-# [1.36.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.35.1...v1.36.0) (2021-05-21)
+* 🐛 dark mode-färgerna tillbaka ([49328b4](https://github.com/kolplattformen/skolplattformen/commit/49328b44f962517910a2e143ddf51cdc083a2d5c))
 
 
 ### Features
 
-* 🎸 Fler språk ([#400](https://github.com/kolplattformen/skolplattformen-app/issues/400)) ([0e8e905](https://github.com/kolplattformen/skolplattformen-app/commit/0e8e90581b7ab3c1705e590dbf0ef6f4a2286f1f))
+* Add custom Poppins typeface ([67a8aca](https://github.com/kolplattformen/skolplattformen/commit/67a8aca9e403ca98fefa8244c205a4cec8669f6a))
+* added day summary on front page ([1917b7e](https://github.com/kolplattformen/skolplattformen/commit/1917b7e2d425b0c40308480668b916156dd3e24a))
+* login screen and move logout button ([fa7b103](https://github.com/kolplattformen/skolplattformen/commit/fa7b10318fdf58ad1e2ef1238bae37c65ba301d5))
+* new colors ([c178f9c](https://github.com/kolplattformen/skolplattformen/commit/c178f9c3b4cd0ae9558df68bb51db48f33537e93))
 
-## [1.35.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.35.0...v1.35.1) (2021-05-17)
+## [1.36.4](https://github.com/kolplattformen/skolplattformen/compare/v1.36.3...v1.36.4) (2021-05-28)
 
 
 ### Bug Fixes
 
-* **site:** dark mode icons ([#396](https://github.com/kolplattformen/skolplattformen-app/issues/396)) ([d85915d](https://github.com/kolplattformen/skolplattformen-app/commit/d85915d79060bdfc68dc6e712716d077d57ae7be))
+* 🐛 Kalender - text blir avklippt ([#410](https://github.com/kolplattformen/skolplattformen/issues/410)) ([377d468](https://github.com/kolplattformen/skolplattformen/commit/377d4684e4b1ef51647b3adcec9dadccbbbc2a76)), closes [#409](https://github.com/kolplattformen/skolplattformen/issues/409)
 
-# [1.35.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.34.2...v1.35.0) (2021-05-17)
+## [1.36.3](https://github.com/kolplattformen/skolplattformen/compare/v1.36.2...v1.36.3) (2021-05-26)
+
+
+### Bug Fixes
+
+* 🐛 add a11y properties for childListItems ([db8434d](https://github.com/kolplattformen/skolplattformen/commit/db8434d7f33b404c2616a69714acc64c1a67d08e)), closes [#354](https://github.com/kolplattformen/skolplattformen/issues/354)
+
+## [1.36.2](https://github.com/kolplattformen/skolplattformen/compare/v1.36.1...v1.36.2) (2021-05-25)
+
+
+### Bug Fixes
+
+* 🐛 knapparna i childListItem pekar rätt igen ([#407](https://github.com/kolplattformen/skolplattformen/issues/407)) ([458daf6](https://github.com/kolplattformen/skolplattformen/commit/458daf6c67c26134dfd27a8a8c0fcef32daf7a45))
+
+## [1.36.1](https://github.com/kolplattformen/skolplattformen/compare/v1.36.0...v1.36.1) (2021-05-25)
+
+
+### Bug Fixes
+
+* 🐛 use modal for login method picker. Fixes [#404](https://github.com/kolplattformen/skolplattformen/issues/404) ([bf472fb](https://github.com/kolplattformen/skolplattformen/commit/bf472fb94389cdb7164e7d6fa042235722c7777e))
+
+# [1.36.0](https://github.com/kolplattformen/skolplattformen/compare/v1.35.1...v1.36.0) (2021-05-21)
 
 
 ### Features
 
-* **site:** dark mode ([#393](https://github.com/kolplattformen/skolplattformen-app/issues/393)) ([36e809a](https://github.com/kolplattformen/skolplattformen-app/commit/36e809a5f007a66ee1c38faf0c8593df44e90bb1))
+* 🎸 Fler språk ([#400](https://github.com/kolplattformen/skolplattformen/issues/400)) ([0e8e905](https://github.com/kolplattformen/skolplattformen/commit/0e8e90581b7ab3c1705e590dbf0ef6f4a2286f1f))
 
-## [1.34.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.34.1...v1.34.2) (2021-05-16)
-
-
-### Bug Fixes
-
-* 🐛 Ord som inte är översatta hämtas från svenska ([6724f3f](https://github.com/kolplattformen/skolplattformen-app/commit/6724f3f683dd1ac81804fc509a775be05c704d29))
-
-## [1.34.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.34.0...v1.34.1) (2021-05-12)
+## [1.35.1](https://github.com/kolplattformen/skolplattformen/compare/v1.35.0...v1.35.1) (2021-05-17)
 
 
 ### Bug Fixes
 
-* 🐛 Added a11y lint and fixes those errors ([a37aeab](https://github.com/kolplattformen/skolplattformen-app/commit/a37aeabf8807e16ac04f59b82ddd40aff3567252))
+* **site:** dark mode icons ([#396](https://github.com/kolplattformen/skolplattformen/issues/396)) ([d85915d](https://github.com/kolplattformen/skolplattformen/commit/d85915d79060bdfc68dc6e712716d077d57ae7be))
 
-# [1.34.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.33.1...v1.34.0) (2021-05-12)
+# [1.35.0](https://github.com/kolplattformen/skolplattformen/compare/v1.34.2...v1.35.0) (2021-05-17)
 
 
 ### Features
 
-* added flash message in header ([b7efee1](https://github.com/kolplattformen/skolplattformen-app/commit/b7efee1e99d932b93d49d6377060d9876f02ea0a))
+* **site:** dark mode ([#393](https://github.com/kolplattformen/skolplattformen/issues/393)) ([36e809a](https://github.com/kolplattformen/skolplattformen/commit/36e809a5f007a66ee1c38faf0c8593df44e90bb1))
 
-## [1.33.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.33.0...v1.33.1) (2021-05-11)
+## [1.34.2](https://github.com/kolplattformen/skolplattformen/compare/v1.34.1...v1.34.2) (2021-05-16)
 
 
 ### Bug Fixes
 
-* 🐛 Fixes dark mode image on children ([19b8f78](https://github.com/kolplattformen/skolplattformen-app/commit/19b8f783187f38fbede905abd833010633c1f9cd)), closes [#388](https://github.com/kolplattformen/skolplattformen-app/issues/388)
+* 🐛 Ord som inte är översatta hämtas från svenska ([6724f3f](https://github.com/kolplattformen/skolplattformen/commit/6724f3f683dd1ac81804fc509a775be05c704d29))
 
-# [1.33.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.32.1...v1.33.0) (2021-05-11)
+## [1.34.1](https://github.com/kolplattformen/skolplattformen/compare/v1.34.0...v1.34.1) (2021-05-12)
+
+
+### Bug Fixes
+
+* 🐛 Added a11y lint and fixes those errors ([a37aeab](https://github.com/kolplattformen/skolplattformen/commit/a37aeabf8807e16ac04f59b82ddd40aff3567252))
+
+# [1.34.0](https://github.com/kolplattformen/skolplattformen/compare/v1.33.1...v1.34.0) (2021-05-12)
 
 
 ### Features
 
-* 🎸 Added current language name to auth screen ([9f15a30](https://github.com/kolplattformen/skolplattformen-app/commit/9f15a303b895b375e34cb9e120bc988c6be558aa)), closes [#367](https://github.com/kolplattformen/skolplattformen-app/issues/367) [#332](https://github.com/kolplattformen/skolplattformen-app/issues/332)
+* added flash message in header ([b7efee1](https://github.com/kolplattformen/skolplattformen/commit/b7efee1e99d932b93d49d6377060d9876f02ea0a))
 
-## [1.32.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.32.0...v1.32.1) (2021-05-11)
+## [1.33.1](https://github.com/kolplattformen/skolplattformen/compare/v1.33.0...v1.33.1) (2021-05-11)
 
 
 ### Bug Fixes
 
-* 🐛 Added Alert Icon when personal number is wrong ([b187c40](https://github.com/kolplattformen/skolplattformen-app/commit/b187c40ecb68c27f781386f96062ee3668b954ba)), closes [#359](https://github.com/kolplattformen/skolplattformen-app/issues/359)
-* 🐛 Improved accessibility on login screen ([d57078b](https://github.com/kolplattformen/skolplattformen-app/commit/d57078b65b33c7b4aa8da87b096e194659ebdc8b)), closes [#351](https://github.com/kolplattformen/skolplattformen-app/issues/351)
+* 🐛 Fixes dark mode image on children ([19b8f78](https://github.com/kolplattformen/skolplattformen/commit/19b8f783187f38fbede905abd833010633c1f9cd)), closes [#388](https://github.com/kolplattformen/skolplattformen/issues/388)
 
-# [1.32.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.31.0...v1.32.0) (2021-05-10)
+# [1.33.0](https://github.com/kolplattformen/skolplattformen/compare/v1.32.1...v1.33.0) (2021-05-11)
 
 
 ### Features
 
-* 🎸 Format calendar dates with weekday ([3923bf1](https://github.com/kolplattformen/skolplattformen-app/commit/3923bf11c41d06dca33c5aaf76cfafd51729c80e))
+* 🎸 Added current language name to auth screen ([9f15a30](https://github.com/kolplattformen/skolplattformen/commit/9f15a303b895b375e34cb9e120bc988c6be558aa)), closes [#367](https://github.com/kolplattformen/skolplattformen/issues/367) [#332](https://github.com/kolplattformen/skolplattformen/issues/332)
 
-# [1.31.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.30.1...v1.31.0) (2021-05-10)
+## [1.32.1](https://github.com/kolplattformen/skolplattformen/compare/v1.32.0...v1.32.1) (2021-05-11)
 
 
 ### Bug Fixes
 
-* 🐛 Fixes background color issue when calender items is empt ([9f96431](https://github.com/kolplattformen/skolplattformen-app/commit/9f964316810f33761beea97e96671b3d8d914bdd))
+* 🐛 Added Alert Icon when personal number is wrong ([b187c40](https://github.com/kolplattformen/skolplattformen/commit/b187c40ecb68c27f781386f96062ee3668b954ba)), closes [#359](https://github.com/kolplattformen/skolplattformen/issues/359)
+* 🐛 Improved accessibility on login screen ([d57078b](https://github.com/kolplattformen/skolplattformen/commit/d57078b65b33c7b4aa8da87b096e194659ebdc8b)), closes [#351](https://github.com/kolplattformen/skolplattformen/issues/351)
+
+# [1.32.0](https://github.com/kolplattformen/skolplattformen/compare/v1.31.0...v1.32.0) (2021-05-10)
 
 
 ### Features
 
-* 🎸 Add clear icon to search input ([6f87887](https://github.com/kolplattformen/skolplattformen-app/commit/6f87887fcd4c726ac7e9697d9087d1036935455c))
+* 🎸 Format calendar dates with weekday ([3923bf1](https://github.com/kolplattformen/skolplattformen/commit/3923bf11c41d06dca33c5aaf76cfafd51729c80e))
 
-## [1.30.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.30.0...v1.30.1) (2021-05-09)
-
-
-### Bug Fixes
-
-* 🐛 Patch fast-fuzzy to remove warning ([45210e1](https://github.com/kolplattformen/skolplattformen-app/commit/45210e15c63b56117c6da6eb3dca1d9187c4da02))
-
-# [1.30.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.29.0...v1.30.0) (2021-05-09)
+# [1.31.0](https://github.com/kolplattformen/skolplattformen/compare/v1.30.1...v1.31.0) (2021-05-10)
 
 
 ### Bug Fixes
 
-* 🐛 Update to React-native 0.64.1 to make build work on xCode 4.5 ([#372](https://github.com/kolplattformen/skolplattformen-app/issues/372)) ([bbe268f](https://github.com/kolplattformen/skolplattformen-app/commit/bbe268f2c25ea31bf928f847c792997c5ca61854))
+* 🐛 Fixes background color issue when calender items is empt ([9f96431](https://github.com/kolplattformen/skolplattformen/commit/9f964316810f33761beea97e96671b3d8d914bdd))
 
 
 ### Features
 
-* 🎸 Add testId to find components in tests ([8636779](https://github.com/kolplattformen/skolplattformen-app/commit/8636779e3cf2ab63f47fef371ae43363c732e87f))
-* 🎸 Change to translated texts in tests ([29273b8](https://github.com/kolplattformen/skolplattformen-app/commit/29273b8566be0d74e1cf1bcfd91b9ab4911c7255))
+* 🎸 Add clear icon to search input ([6f87887](https://github.com/kolplattformen/skolplattformen/commit/6f87887fcd4c726ac7e9697d9087d1036935455c))
 
-# [1.29.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.28.1...v1.29.0) (2021-05-09)
+## [1.30.1](https://github.com/kolplattformen/skolplattformen/compare/v1.30.0...v1.30.1) (2021-05-09)
 
 
 ### Bug Fixes
 
-* 🐛 formattering av schema som försvann är tillbaka ([#371](https://github.com/kolplattformen/skolplattformen-app/issues/371)) ([fbc8514](https://github.com/kolplattformen/skolplattformen-app/commit/fbc85140521f23e47a57fe33789815d8c268708d))
+* 🐛 Patch fast-fuzzy to remove warning ([45210e1](https://github.com/kolplattformen/skolplattformen/commit/45210e15c63b56117c6da6eb3dca1d9187c4da02))
+
+# [1.30.0](https://github.com/kolplattformen/skolplattformen/compare/v1.29.0...v1.30.0) (2021-05-09)
+
+
+### Bug Fixes
+
+* 🐛 Update to React-native 0.64.1 to make build work on xCode 4.5 ([#372](https://github.com/kolplattformen/skolplattformen/issues/372)) ([bbe268f](https://github.com/kolplattformen/skolplattformen/commit/bbe268f2c25ea31bf928f847c792997c5ca61854))
 
 
 ### Features
 
-* 🎸 Replace abort with cancel ([134e904](https://github.com/kolplattformen/skolplattformen-app/commit/134e904d86b0295614a4fd452355276b412d4e65))
+* 🎸 Add testId to find components in tests ([8636779](https://github.com/kolplattformen/skolplattformen/commit/8636779e3cf2ab63f47fef371ae43363c732e87f))
+* 🎸 Change to translated texts in tests ([29273b8](https://github.com/kolplattformen/skolplattformen/commit/29273b8566be0d74e1cf1bcfd91b9ab4911c7255))
 
-## [1.28.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.28.0...v1.28.1) (2021-05-06)
+# [1.29.0](https://github.com/kolplattformen/skolplattformen/compare/v1.28.1...v1.29.0) (2021-05-09)
 
 
 ### Bug Fixes
 
-* 🐛 android layout fixes after dark mode ([#369](https://github.com/kolplattformen/skolplattformen-app/issues/369)) ([683afe1](https://github.com/kolplattformen/skolplattformen-app/commit/683afe15f83f0321866615da54d5e5a1d5752f4f))
-
-# [1.28.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.5...v1.28.0) (2021-05-06)
+* 🐛 formattering av schema som försvann är tillbaka ([#371](https://github.com/kolplattformen/skolplattformen/issues/371)) ([fbc8514](https://github.com/kolplattformen/skolplattformen/commit/fbc85140521f23e47a57fe33789815d8c268708d))
 
 
 ### Features
 
-* 🎸 Dark mode ([#364](https://github.com/kolplattformen/skolplattformen-app/issues/364)) ([bd9a4f5](https://github.com/kolplattformen/skolplattformen-app/commit/bd9a4f54b9f59e1ab675f5454380d8985b4a75df))
+* 🎸 Replace abort with cancel ([134e904](https://github.com/kolplattformen/skolplattformen/commit/134e904d86b0295614a4fd452355276b412d4e65))
 
-## [1.27.5](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.4...v1.27.5) (2021-05-02)
-
-
-### Bug Fixes
-
-* 🐛 Fixes crash in ViewPager when setting selectedIndex ([#347](https://github.com/kolplattformen/skolplattformen-app/issues/347)) ([a358351](https://github.com/kolplattformen/skolplattformen-app/commit/a358351a3a3c6d0b7f1d7469b96c23fab0461d5a))
-
-## [1.27.4](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.3...v1.27.4) (2021-04-30)
+## [1.28.1](https://github.com/kolplattformen/skolplattformen/compare/v1.28.0...v1.28.1) (2021-05-06)
 
 
 ### Bug Fixes
 
-* 🐛 Formatering nyhetsbrev. Bumpade version på embedded-api ([#345](https://github.com/kolplattformen/skolplattformen-app/issues/345)) ([7e2fd8f](https://github.com/kolplattformen/skolplattformen-app/commit/7e2fd8f74ddf3fe3d50fc1753d89780fd85e7515))
+* 🐛 android layout fixes after dark mode ([#369](https://github.com/kolplattformen/skolplattformen/issues/369)) ([683afe1](https://github.com/kolplattformen/skolplattformen/commit/683afe15f83f0321866615da54d5e5a1d5752f4f))
 
-## [1.27.3](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.2...v1.27.3) (2021-04-30)
-
-
-### Bug Fixes
-
-* 🐛 Day is selected after data is loaded ([ccaa17b](https://github.com/kolplattformen/skolplattformen-app/commit/ccaa17bf962a6e93898c9fc06d22403e10d9b528))
-
-## [1.27.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.1...v1.27.2) (2021-04-29)
-
-
-### Bug Fixes
-
-* 🐛 schema syns inte om kalender är tom ([#342](https://github.com/kolplattformen/skolplattformen-app/issues/342)) ([d9bcc06](https://github.com/kolplattformen/skolplattformen-app/commit/d9bcc06df36474a77fa4c314ec51af3e9c423de8))
-
-## [1.27.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.27.0...v1.27.1) (2021-04-28)
-
-
-### Bug Fixes
-
-* 🐛 Fixes lunch rendering ([#341](https://github.com/kolplattformen/skolplattformen-app/issues/341)) ([6c75d9d](https://github.com/kolplattformen/skolplattformen-app/commit/6c75d9d1191fa4c6b8f92fe526e4c1f85915bddf))
-
-# [1.27.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.26.0...v1.27.0) (2021-04-28)
+# [1.28.0](https://github.com/kolplattformen/skolplattformen/compare/v1.27.5...v1.28.0) (2021-05-06)
 
 
 ### Features
 
-* **a11y:** update colors and styling to improve accessibility ([9dd9691](https://github.com/kolplattformen/skolplattformen-app/commit/9dd9691aa94e33d9525c3ca96a9cfd0d35ef13b2))
+* 🎸 Dark mode ([#364](https://github.com/kolplattformen/skolplattformen/issues/364)) ([bd9a4f5](https://github.com/kolplattformen/skolplattformen/commit/bd9a4f54b9f59e1ab675f5454380d8985b4a75df))
 
-# [1.26.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.25.0...v1.26.0) (2021-04-28)
+## [1.27.5](https://github.com/kolplattformen/skolplattformen/compare/v1.27.4...v1.27.5) (2021-05-02)
 
 
 ### Bug Fixes
 
-* 🐛 Förbättrad markdown-parsning ([9546540](https://github.com/kolplattformen/skolplattformen-app/commit/9546540d936f73eda70f236037d1f7ee37b5a0de))
-* 🐛 Förbättrad markdown-parsning ([6d3ff81](https://github.com/kolplattformen/skolplattformen-app/commit/6d3ff81185270df82863fed135e35bfcf4c76f79))
-* 🐛 Localised names of days ([fe27819](https://github.com/kolplattformen/skolplattformen-app/commit/fe2781994d7456cbc04f730d6a69a2dcc6c3f0f0))
-* 🐛 Localised names of days ([f31c93b](https://github.com/kolplattformen/skolplattformen-app/commit/f31c93b3d69ed02ec78b22721b0af86f23c4c968))
-* 🐛 Removed console.log ([9671fa2](https://github.com/kolplattformen/skolplattformen-app/commit/9671fa223db6a35f886488ce818071b783c5d639))
-* 🐛 Removed console.log ([9266711](https://github.com/kolplattformen/skolplattformen-app/commit/9266711e7eafa301bb1bdf1dfe556d78ef09c44b))
-* 🐛 Renamed misnamed location ([fba0c61](https://github.com/kolplattformen/skolplattformen-app/commit/fba0c617091dd04743b7d10a36d5f8879eca131b))
-* 🐛 Renamed misnamed location ([d537a6d](https://github.com/kolplattformen/skolplattformen-app/commit/d537a6d5eb84f8ad9350d0a6a31c641e47118308))
-* 🐛 uppdaterade version av embedded-api ([ebb0340](https://github.com/kolplattformen/skolplattformen-app/commit/ebb03408a1911f014bf1ab5e40af3c6f8693621a))
-* 🐛 uppdaterade version av embedded-api ([eaa2353](https://github.com/kolplattformen/skolplattformen-app/commit/eaa23539a1202a5a12a771149d175c043f942b35))
-* bug when getting next weeks schedule ([036968b](https://github.com/kolplattformen/skolplattformen-app/commit/036968bfc395e933c18a52b3e9f7d71fac7ee810))
-* bug when getting next weeks schedule ([fc22916](https://github.com/kolplattformen/skolplattformen-app/commit/fc2291605e017e1b8e5e908078c4df50d1ec66ef))
-* linter is picky ([3af39c1](https://github.com/kolplattformen/skolplattformen-app/commit/3af39c14be9d74193bbdae8f977601c85c9601d0))
-* linter is picky ([a2846cd](https://github.com/kolplattformen/skolplattformen-app/commit/a2846cdb35bc6df581a8b1584087b3415cbe110f))
+* 🐛 Fixes crash in ViewPager when setting selectedIndex ([#347](https://github.com/kolplattformen/skolplattformen/issues/347)) ([a358351](https://github.com/kolplattformen/skolplattformen/commit/a358351a3a3c6d0b7f1d7469b96c23fab0461d5a))
+
+## [1.27.4](https://github.com/kolplattformen/skolplattformen/compare/v1.27.3...v1.27.4) (2021-04-30)
+
+
+### Bug Fixes
+
+* 🐛 Formatering nyhetsbrev. Bumpade version på embedded-api ([#345](https://github.com/kolplattformen/skolplattformen/issues/345)) ([7e2fd8f](https://github.com/kolplattformen/skolplattformen/commit/7e2fd8f74ddf3fe3d50fc1753d89780fd85e7515))
+
+## [1.27.3](https://github.com/kolplattformen/skolplattformen/compare/v1.27.2...v1.27.3) (2021-04-30)
+
+
+### Bug Fixes
+
+* 🐛 Day is selected after data is loaded ([ccaa17b](https://github.com/kolplattformen/skolplattformen/commit/ccaa17bf962a6e93898c9fc06d22403e10d9b528))
+
+## [1.27.2](https://github.com/kolplattformen/skolplattformen/compare/v1.27.1...v1.27.2) (2021-04-29)
+
+
+### Bug Fixes
+
+* 🐛 schema syns inte om kalender är tom ([#342](https://github.com/kolplattformen/skolplattformen/issues/342)) ([d9bcc06](https://github.com/kolplattformen/skolplattformen/commit/d9bcc06df36474a77fa4c314ec51af3e9c423de8))
+
+## [1.27.1](https://github.com/kolplattformen/skolplattformen/compare/v1.27.0...v1.27.1) (2021-04-28)
+
+
+### Bug Fixes
+
+* 🐛 Fixes lunch rendering ([#341](https://github.com/kolplattformen/skolplattformen/issues/341)) ([6c75d9d](https://github.com/kolplattformen/skolplattformen/commit/6c75d9d1191fa4c6b8f92fe526e4c1f85915bddf))
+
+# [1.27.0](https://github.com/kolplattformen/skolplattformen/compare/v1.26.0...v1.27.0) (2021-04-28)
 
 
 ### Features
 
-* 🎸 Polish support in curriculum ([b8ef523](https://github.com/kolplattformen/skolplattformen-app/commit/b8ef523afc7de1554a782063a6f7679498aa7fef))
-* 🎸 Polish support in curriculum ([96c816e](https://github.com/kolplattformen/skolplattformen-app/commit/96c816e33c113c8da5b6e5bb695a8bdaf7d88a7f))
-* 🎸 Updated deps and removed unnecessary parsing in week ([586a975](https://github.com/kolplattformen/skolplattformen-app/commit/586a9759207dc0a53b277c451c7341e44dca479d))
-* first working schema ui ([d3d2be3](https://github.com/kolplattformen/skolplattformen-app/commit/d3d2be3a3e3c5910f698ea1c2c8f815b0e688aca))
-* first working schema ui ([8b69a20](https://github.com/kolplattformen/skolplattformen-app/commit/8b69a20ab2dc9fde5ae90b716a1646ab606fbd02))
-* first working version in test ([0a8be80](https://github.com/kolplattformen/skolplattformen-app/commit/0a8be80a1d12885bca5599bbb9376d710dd3e150))
-* first working version in test ([4bf571b](https://github.com/kolplattformen/skolplattformen-app/commit/4bf571b5d8c7cb5da2453330ef22e3e4b8ae2c7d))
-* use curriculun lib ([8b700e5](https://github.com/kolplattformen/skolplattformen-app/commit/8b700e5516414d4e0c4e70a2ff64a245645d1cd3))
-* use curriculun lib ([0e61c16](https://github.com/kolplattformen/skolplattformen-app/commit/0e61c16aa94761c6eb48c61cbd368ea288bd5b9d))
-* visa summering per dag inkl indikation om gymnastik ([ea18203](https://github.com/kolplattformen/skolplattformen-app/commit/ea182035d8960316a34f5fdd9c3a4769b3d1aa57))
-* visa summering per dag inkl indikation om gymnastik ([02eb7dc](https://github.com/kolplattformen/skolplattformen-app/commit/02eb7dcf92df6f25e28bc146255a7f4dc785ac58))
+* **a11y:** update colors and styling to improve accessibility ([9dd9691](https://github.com/kolplattformen/skolplattformen/commit/9dd9691aa94e33d9525c3ca96a9cfd0d35ef13b2))
 
-# [1.25.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.24.1...v1.25.0) (2021-04-25)
+# [1.26.0](https://github.com/kolplattformen/skolplattformen/compare/v1.25.0...v1.26.0) (2021-04-28)
+
+
+### Bug Fixes
+
+* 🐛 Förbättrad markdown-parsning ([9546540](https://github.com/kolplattformen/skolplattformen/commit/9546540d936f73eda70f236037d1f7ee37b5a0de))
+* 🐛 Förbättrad markdown-parsning ([6d3ff81](https://github.com/kolplattformen/skolplattformen/commit/6d3ff81185270df82863fed135e35bfcf4c76f79))
+* 🐛 Localised names of days ([fe27819](https://github.com/kolplattformen/skolplattformen/commit/fe2781994d7456cbc04f730d6a69a2dcc6c3f0f0))
+* 🐛 Localised names of days ([f31c93b](https://github.com/kolplattformen/skolplattformen/commit/f31c93b3d69ed02ec78b22721b0af86f23c4c968))
+* 🐛 Removed console.log ([9671fa2](https://github.com/kolplattformen/skolplattformen/commit/9671fa223db6a35f886488ce818071b783c5d639))
+* 🐛 Removed console.log ([9266711](https://github.com/kolplattformen/skolplattformen/commit/9266711e7eafa301bb1bdf1dfe556d78ef09c44b))
+* 🐛 Renamed misnamed location ([fba0c61](https://github.com/kolplattformen/skolplattformen/commit/fba0c617091dd04743b7d10a36d5f8879eca131b))
+* 🐛 Renamed misnamed location ([d537a6d](https://github.com/kolplattformen/skolplattformen/commit/d537a6d5eb84f8ad9350d0a6a31c641e47118308))
+* 🐛 uppdaterade version av embedded-api ([ebb0340](https://github.com/kolplattformen/skolplattformen/commit/ebb03408a1911f014bf1ab5e40af3c6f8693621a))
+* 🐛 uppdaterade version av embedded-api ([eaa2353](https://github.com/kolplattformen/skolplattformen/commit/eaa23539a1202a5a12a771149d175c043f942b35))
+* bug when getting next weeks schedule ([036968b](https://github.com/kolplattformen/skolplattformen/commit/036968bfc395e933c18a52b3e9f7d71fac7ee810))
+* bug when getting next weeks schedule ([fc22916](https://github.com/kolplattformen/skolplattformen/commit/fc2291605e017e1b8e5e908078c4df50d1ec66ef))
+* linter is picky ([3af39c1](https://github.com/kolplattformen/skolplattformen/commit/3af39c14be9d74193bbdae8f977601c85c9601d0))
+* linter is picky ([a2846cd](https://github.com/kolplattformen/skolplattformen/commit/a2846cdb35bc6df581a8b1584087b3415cbe110f))
 
 
 ### Features
 
-* 🎸 Added useAppState hook and logs out user if not authenticated ([#328](https://github.com/kolplattformen/skolplattformen-app/issues/328)) ([772f652](https://github.com/kolplattformen/skolplattformen-app/commit/772f65273c4858eac680594f61dc7ac92c30faa0))
+* 🎸 Polish support in curriculum ([b8ef523](https://github.com/kolplattformen/skolplattformen/commit/b8ef523afc7de1554a782063a6f7679498aa7fef))
+* 🎸 Polish support in curriculum ([96c816e](https://github.com/kolplattformen/skolplattformen/commit/96c816e33c113c8da5b6e5bb695a8bdaf7d88a7f))
+* 🎸 Updated deps and removed unnecessary parsing in week ([586a975](https://github.com/kolplattformen/skolplattformen/commit/586a9759207dc0a53b277c451c7341e44dca479d))
+* first working schema ui ([d3d2be3](https://github.com/kolplattformen/skolplattformen/commit/d3d2be3a3e3c5910f698ea1c2c8f815b0e688aca))
+* first working schema ui ([8b69a20](https://github.com/kolplattformen/skolplattformen/commit/8b69a20ab2dc9fde5ae90b716a1646ab606fbd02))
+* first working version in test ([0a8be80](https://github.com/kolplattformen/skolplattformen/commit/0a8be80a1d12885bca5599bbb9376d710dd3e150))
+* first working version in test ([4bf571b](https://github.com/kolplattformen/skolplattformen/commit/4bf571b5d8c7cb5da2453330ef22e3e4b8ae2c7d))
+* use curriculun lib ([8b700e5](https://github.com/kolplattformen/skolplattformen/commit/8b700e5516414d4e0c4e70a2ff64a245645d1cd3))
+* use curriculun lib ([0e61c16](https://github.com/kolplattformen/skolplattformen/commit/0e61c16aa94761c6eb48c61cbd368ea288bd5b9d))
+* visa summering per dag inkl indikation om gymnastik ([ea18203](https://github.com/kolplattformen/skolplattformen/commit/ea182035d8960316a34f5fdd9c3a4769b3d1aa57))
+* visa summering per dag inkl indikation om gymnastik ([02eb7dc](https://github.com/kolplattformen/skolplattformen/commit/02eb7dcf92df6f25e28bc146255a7f4dc785ac58))
 
-## [1.24.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.24.0...v1.24.1) (2021-04-23)
-
-
-### Bug Fixes
-
-* **site:** screenshot alignment ([#326](https://github.com/kolplattformen/skolplattformen-app/issues/326)) ([e777b69](https://github.com/kolplattformen/skolplattformen-app/commit/e777b693c337722e381141e71825047e89cad41f))
-
-# [1.24.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.23.0...v1.24.0) (2021-04-21)
-
-
-### Features
-
-* Add Patreon badge. Add info about contributing with Weblate. ([#311](https://github.com/kolplattformen/skolplattformen-app/issues/311)) ([b37571d](https://github.com/kolplattformen/skolplattformen-app/commit/b37571d0123aa85f5b132a87fb1753a103dd702b))
-
-# [1.23.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.22.1...v1.23.0) (2021-04-21)
+# [1.25.0](https://github.com/kolplattformen/skolplattformen/compare/v1.24.1...v1.25.0) (2021-04-25)
 
 
 ### Features
 
-* 🎸 Gratis ([#312](https://github.com/kolplattformen/skolplattformen-app/issues/312)) ([ac8581d](https://github.com/kolplattformen/skolplattformen-app/commit/ac8581d0b96771883ef91ea0445d360972c6ed73))
+* 🎸 Added useAppState hook and logs out user if not authenticated ([#328](https://github.com/kolplattformen/skolplattformen/issues/328)) ([772f652](https://github.com/kolplattformen/skolplattformen/commit/772f65273c4858eac680594f61dc7ac92c30faa0))
 
-## [1.22.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.22.0...v1.22.1) (2021-04-20)
+## [1.24.1](https://github.com/kolplattformen/skolplattformen/compare/v1.24.0...v1.24.1) (2021-04-23)
 
 
 ### Bug Fixes
 
-* 🐛 Lade tillbaka utbildningsnivå under barnets namn ([#307](https://github.com/kolplattformen/skolplattformen-app/issues/307)) ([659cb36](https://github.com/kolplattformen/skolplattformen-app/commit/659cb36b09770e46db55175544ab246d470196b6))
+* **site:** screenshot alignment ([#326](https://github.com/kolplattformen/skolplattformen/issues/326)) ([e777b69](https://github.com/kolplattformen/skolplattformen/commit/e777b693c337722e381141e71825047e89cad41f))
 
-# [1.22.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.21.1...v1.22.0) (2021-04-20)
+# [1.24.0](https://github.com/kolplattformen/skolplattformen/compare/v1.23.0...v1.24.0) (2021-04-21)
 
 
 ### Features
 
-* 🎸 Added Polish ([bb35884](https://github.com/kolplattformen/skolplattformen-app/commit/bb35884651d7b9af5959b10c3d0ed778e9f6d017))
+* Add Patreon badge. Add info about contributing with Weblate. ([#311](https://github.com/kolplattformen/skolplattformen/issues/311)) ([b37571d](https://github.com/kolplattformen/skolplattformen/commit/b37571d0123aa85f5b132a87fb1753a103dd702b))
 
-## [1.21.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.21.0...v1.21.1) (2021-04-20)
-
-
-### Bug Fixes
-
-* 🐛 Adress call turned off everywhere ([b95c9e7](https://github.com/kolplattformen/skolplattformen-app/commit/b95c9e77cf9adb4d1521cff1af992dba34325641))
-
-# [1.21.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.20.1...v1.21.0) (2021-04-20)
-
-
-### Bug Fixes
-
-* 🐛 added import of moment locales for available languages ([e7c0d55](https://github.com/kolplattformen/skolplattformen-app/commit/e7c0d5568bec28e0745752d5205b576180ea08fb))
+# [1.23.0](https://github.com/kolplattformen/skolplattformen/compare/v1.22.1...v1.23.0) (2021-04-21)
 
 
 ### Features
 
-* 🎸 Added Polish language ([53f6d4c](https://github.com/kolplattformen/skolplattformen-app/commit/53f6d4c4f0559c7a39a419ce49108d9ca7c1137b))
+* 🎸 Gratis ([#312](https://github.com/kolplattformen/skolplattformen/issues/312)) ([ac8581d](https://github.com/kolplattformen/skolplattformen/commit/ac8581d0b96771883ef91ea0445d360972c6ed73))
 
-## [1.20.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.20.0...v1.20.1) (2021-04-19)
+## [1.22.1](https://github.com/kolplattformen/skolplattformen/compare/v1.22.0...v1.22.1) (2021-04-20)
 
 
 ### Bug Fixes
 
-* 🐛 uppdatering av QA sidan ([c90aeff](https://github.com/kolplattformen/skolplattformen-app/commit/c90aeffe36c520db4cd3e53766f9c5e7784b7432))
+* 🐛 Lade tillbaka utbildningsnivå under barnets namn ([#307](https://github.com/kolplattformen/skolplattformen/issues/307)) ([659cb36](https://github.com/kolplattformen/skolplattformen/commit/659cb36b09770e46db55175544ab246d470196b6))
 
-# [1.20.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.19.1...v1.20.0) (2021-04-19)
+# [1.22.0](https://github.com/kolplattformen/skolplattformen/compare/v1.21.1...v1.22.0) (2021-04-20)
 
 
 ### Features
 
-* 🎸 Redesign of webview, simpler interface ([#287](https://github.com/kolplattformen/skolplattformen-app/issues/287)) ([5723b19](https://github.com/kolplattformen/skolplattformen-app/commit/5723b198f74ed5f5298bee21e4e2c8e4aef08401))
+* 🎸 Added Polish ([bb35884](https://github.com/kolplattformen/skolplattformen/commit/bb35884651d7b9af5959b10c3d0ed778e9f6d017))
 
-## [1.19.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.19.0...v1.19.1) (2021-04-18)
+## [1.21.1](https://github.com/kolplattformen/skolplattformen/compare/v1.21.0...v1.21.1) (2021-04-20)
 
 
 ### Bug Fixes
 
-* 🐛 Settings menu was not updated on language change ([#286](https://github.com/kolplattformen/skolplattformen-app/issues/286)) ([6418d6e](https://github.com/kolplattformen/skolplattformen-app/commit/6418d6ee42e5f953b2a1f83613f07f7e0f2963d8))
+* 🐛 Adress call turned off everywhere ([b95c9e7](https://github.com/kolplattformen/skolplattformen/commit/b95c9e77cf9adb4d1521cff1af992dba34325641))
 
-# [1.19.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.18.0...v1.19.0) (2021-04-18)
+# [1.21.0](https://github.com/kolplattformen/skolplattformen/compare/v1.20.1...v1.21.0) (2021-04-20)
+
+
+### Bug Fixes
+
+* 🐛 added import of moment locales for available languages ([e7c0d55](https://github.com/kolplattformen/skolplattformen/commit/e7c0d5568bec28e0745752d5205b576180ea08fb))
 
 
 ### Features
 
-* 🎸 Add errormessage to loading page ([#255](https://github.com/kolplattformen/skolplattformen-app/issues/255)) ([d1c5b09](https://github.com/kolplattformen/skolplattformen-app/commit/d1c5b09cf31113318f9811bea16d809dbde90c4e)), closes [#195](https://github.com/kolplattformen/skolplattformen-app/issues/195)
+* 🎸 Added Polish language ([53f6d4c](https://github.com/kolplattformen/skolplattformen/commit/53f6d4c4f0559c7a39a419ce49108d9ca7c1137b))
 
-# [1.18.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.17.0...v1.18.0) (2021-04-17)
+## [1.20.1](https://github.com/kolplattformen/skolplattformen/compare/v1.20.0...v1.20.1) (2021-04-19)
+
+
+### Bug Fixes
+
+* 🐛 uppdatering av QA sidan ([c90aeff](https://github.com/kolplattformen/skolplattformen/commit/c90aeffe36c520db4cd3e53766f9c5e7784b7432))
+
+# [1.20.0](https://github.com/kolplattformen/skolplattformen/compare/v1.19.1...v1.20.0) (2021-04-19)
 
 
 ### Features
 
-* 🎸 Add new Status page ([#259](https://github.com/kolplattformen/skolplattformen-app/issues/259)) ([2dd1564](https://github.com/kolplattformen/skolplattformen-app/commit/2dd15640e2020d92486511b1dd330eaa0b8559c5))
+* 🎸 Redesign of webview, simpler interface ([#287](https://github.com/kolplattformen/skolplattformen/issues/287)) ([5723b19](https://github.com/kolplattformen/skolplattformen/commit/5723b198f74ed5f5298bee21e4e2c8e4aef08401))
 
-# [1.17.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.16.1...v1.17.0) (2021-04-17)
+## [1.19.1](https://github.com/kolplattformen/skolplattformen/compare/v1.19.0...v1.19.1) (2021-04-18)
+
+
+### Bug Fixes
+
+* 🐛 Settings menu was not updated on language change ([#286](https://github.com/kolplattformen/skolplattformen/issues/286)) ([6418d6e](https://github.com/kolplattformen/skolplattformen/commit/6418d6ee42e5f953b2a1f83613f07f7e0f2963d8))
+
+# [1.19.0](https://github.com/kolplattformen/skolplattformen/compare/v1.18.0...v1.19.0) (2021-04-18)
 
 
 ### Features
 
-* 🎸 Remove required personal number on login on same device ([#271](https://github.com/kolplattformen/skolplattformen-app/issues/271)) ([2604640](https://github.com/kolplattformen/skolplattformen-app/commit/260464026b39d3e66098df037a19a9fe586a000c))
+* 🎸 Add errormessage to loading page ([#255](https://github.com/kolplattformen/skolplattformen/issues/255)) ([d1c5b09](https://github.com/kolplattformen/skolplattformen/commit/d1c5b09cf31113318f9811bea16d809dbde90c4e)), closes [#195](https://github.com/kolplattformen/skolplattformen/issues/195)
 
-## [1.16.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.16.0...v1.16.1) (2021-04-17)
-
-
-### Bug Fixes
-
-* 🐛 Fixes issue where locale was not saved ([19554c7](https://github.com/kolplattformen/skolplattformen-app/commit/19554c788fec4d37e8d86a654a83c960704f8c61)), closes [#280](https://github.com/kolplattformen/skolplattformen-app/issues/280)
-
-# [1.16.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.15.1...v1.16.0) (2021-04-16)
+# [1.18.0](https://github.com/kolplattformen/skolplattformen/compare/v1.17.0...v1.18.0) (2021-04-17)
 
 
 ### Features
 
-* 🎸 Added text for empty menu ([bbfb2a3](https://github.com/kolplattformen/skolplattformen-app/commit/bbfb2a36aea659b91ba1ed528691066caf0c0cef))
-* 🎸 Updated embedded-api for better menu handling ([675454a](https://github.com/kolplattformen/skolplattformen-app/commit/675454a2fe9be5738c6965971da9db2f7b4c75a4))
+* 🎸 Add new Status page ([#259](https://github.com/kolplattformen/skolplattformen/issues/259)) ([2dd1564](https://github.com/kolplattformen/skolplattformen/commit/2dd15640e2020d92486511b1dd330eaa0b8559c5))
 
-## [1.15.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.15.0...v1.15.1) (2021-04-16)
-
-
-### Bug Fixes
-
-* 🐛 Remove two packages that have security issues ([5a0d673](https://github.com/kolplattformen/skolplattformen-app/commit/5a0d67363d549fa5f431cce8f23e061acd5cc33c))
-
-# [1.15.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.14.0...v1.15.0) (2021-04-13)
+# [1.17.0](https://github.com/kolplattformen/skolplattformen/compare/v1.16.1...v1.17.0) (2021-04-17)
 
 
 ### Features
 
-* 🎸 Updated curriculum ([#268](https://github.com/kolplattformen/skolplattformen-app/issues/268)) ([960be8a](https://github.com/kolplattformen/skolplattformen-app/commit/960be8a33460e3fe40cd9477e9b3c805bbbb88d9))
+* 🎸 Remove required personal number on login on same device ([#271](https://github.com/kolplattformen/skolplattformen/issues/271)) ([2604640](https://github.com/kolplattformen/skolplattformen/commit/260464026b39d3e66098df037a19a9fe586a000c))
 
-# [1.14.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.13.0...v1.14.0) (2021-04-13)
+## [1.16.1](https://github.com/kolplattformen/skolplattformen/compare/v1.16.0...v1.16.1) (2021-04-17)
 
 
 ### Bug Fixes
 
-* 🐛 Downgraded react-native testing lib ([14e9ad8](https://github.com/kolplattformen/skolplattformen-app/commit/14e9ad89727d980055ebbb35f1a44ea06a932467))
-* 🐛 Reverting to old api-hooks to isolate problem ([5945651](https://github.com/kolplattformen/skolplattformen-app/commit/5945651803ce111b3bd4d4a059b045e22947dedc))
+* 🐛 Fixes issue where locale was not saved ([19554c7](https://github.com/kolplattformen/skolplattformen/commit/19554c788fec4d37e8d86a654a83c960704f8c61)), closes [#280](https://github.com/kolplattformen/skolplattformen/issues/280)
+
+# [1.16.0](https://github.com/kolplattformen/skolplattformen/compare/v1.15.1...v1.16.0) (2021-04-16)
 
 
 ### Features
 
-* 🎸 Updated embedded-api and api-hooks ([5a3391a](https://github.com/kolplattformen/skolplattformen-app/commit/5a3391ad2423e323c6dc217ea3c22b6d233925db))
-* 🎸 Updated embedded-api for time tables with full names ([bc1e638](https://github.com/kolplattformen/skolplattformen-app/commit/bc1e638426814669fe38daa769a078502251228b))
-* 🎸 Working compound child list enabling time tables ([323fc13](https://github.com/kolplattformen/skolplattformen-app/commit/323fc13efee2c8b27546c2b29192772ddbb9628d))
+* 🎸 Added text for empty menu ([bbfb2a3](https://github.com/kolplattformen/skolplattformen/commit/bbfb2a36aea659b91ba1ed528691066caf0c0cef))
+* 🎸 Updated embedded-api for better menu handling ([675454a](https://github.com/kolplattformen/skolplattformen/commit/675454a2fe9be5738c6965971da9db2f7b4c75a4))
 
-# [1.13.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.12.0...v1.13.0) (2021-04-07)
+## [1.15.1](https://github.com/kolplattformen/skolplattformen/compare/v1.15.0...v1.15.1) (2021-04-16)
+
+
+### Bug Fixes
+
+* 🐛 Remove two packages that have security issues ([5a0d673](https://github.com/kolplattformen/skolplattformen/commit/5a0d67363d549fa5f431cce8f23e061acd5cc33c))
+
+# [1.15.0](https://github.com/kolplattformen/skolplattformen/compare/v1.14.0...v1.15.0) (2021-04-13)
 
 
 ### Features
 
-* **site:** uppdatera timeline med april ([#264](https://github.com/kolplattformen/skolplattformen-app/issues/264)) ([ddf74eb](https://github.com/kolplattformen/skolplattformen-app/commit/ddf74ebdf3054069196bbea72d48c9377ec004f9))
+* 🎸 Updated curriculum ([#268](https://github.com/kolplattformen/skolplattformen/issues/268)) ([960be8a](https://github.com/kolplattformen/skolplattformen/commit/960be8a33460e3fe40cd9477e9b3c805bbbb88d9))
 
-# [1.12.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.11.1...v1.12.0) (2021-04-05)
+# [1.14.0](https://github.com/kolplattformen/skolplattformen/compare/v1.13.0...v1.14.0) (2021-04-13)
+
+
+### Bug Fixes
+
+* 🐛 Downgraded react-native testing lib ([14e9ad8](https://github.com/kolplattformen/skolplattformen/commit/14e9ad89727d980055ebbb35f1a44ea06a932467))
+* 🐛 Reverting to old api-hooks to isolate problem ([5945651](https://github.com/kolplattformen/skolplattformen/commit/5945651803ce111b3bd4d4a059b045e22947dedc))
 
 
 ### Features
 
-* 🎸 Upgrade embedded-api to 3.0.2 ([654471f](https://github.com/kolplattformen/skolplattformen-app/commit/654471f8030f413e56d9ecdb7c21f730bdef4aff))
+* 🎸 Updated embedded-api and api-hooks ([5a3391a](https://github.com/kolplattformen/skolplattformen/commit/5a3391ad2423e323c6dc217ea3c22b6d233925db))
+* 🎸 Updated embedded-api for time tables with full names ([bc1e638](https://github.com/kolplattformen/skolplattformen/commit/bc1e638426814669fe38daa769a078502251228b))
+* 🎸 Working compound child list enabling time tables ([323fc13](https://github.com/kolplattformen/skolplattformen/commit/323fc13efee2c8b27546c2b29192772ddbb9628d))
 
-## [1.11.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.11.0...v1.11.1) (2021-04-03)
-
-
-### Bug Fixes
-
-* 🐛 Remove warning on markdown component '... unique key ..' ([5ab6ce2](https://github.com/kolplattformen/skolplattformen-app/commit/5ab6ce2b094aa5becfdb633ec8af071f49fa50ed))
-
-# [1.11.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.10.4...v1.11.0) (2021-04-03)
+# [1.13.0](https://github.com/kolplattformen/skolplattformen/compare/v1.12.0...v1.13.0) (2021-04-07)
 
 
 ### Features
 
-* 🎸 Datum i kalendern ([b1e2d4f](https://github.com/kolplattformen/skolplattformen-app/commit/b1e2d4f541f44ac0223d12719d1e1caf0f28fd02))
+* **site:** uppdatera timeline med april ([#264](https://github.com/kolplattformen/skolplattformen/issues/264)) ([ddf74eb](https://github.com/kolplattformen/skolplattformen/commit/ddf74ebdf3054069196bbea72d48c9377ec004f9))
 
-## [1.10.4](https://github.com/kolplattformen/skolplattformen-app/compare/v1.10.3...v1.10.4) (2021-04-02)
-
-
-### Bug Fixes
-
-* 🐛 calendar sorting ([c0f5336](https://github.com/kolplattformen/skolplattformen-app/commit/c0f5336012c7fc7145ba042a1df76054ba1aed75))
-
-## [1.10.3](https://github.com/kolplattformen/skolplattformen-app/compare/v1.10.2...v1.10.3) (2021-04-02)
-
-
-### Bug Fixes
-
-* 🐛 siffran vid kalenderikonen visade fel antal ([b34a2c2](https://github.com/kolplattformen/skolplattformen-app/commit/b34a2c20b6b28b3de9cd8bc226813d5b02857144))
-
-## [1.10.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.10.1...v1.10.2) (2021-04-02)
-
-
-### Bug Fixes
-
-* 🐛 Fixes issue where settings icon was hidden on Android ([f3d3af1](https://github.com/kolplattformen/skolplattformen-app/commit/f3d3af1b6e30fa011a6d553b5c9e210aca63cc5c)), closes [#180](https://github.com/kolplattformen/skolplattformen-app/issues/180)
-
-## [1.10.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.10.0...v1.10.1) (2021-04-01)
-
-
-### Bug Fixes
-
-* fel i datumhantering ([#241](https://github.com/kolplattformen/skolplattformen-app/issues/241)) ([7e1b068](https://github.com/kolplattformen/skolplattformen-app/commit/7e1b068e8f8fc3a23ad16cc25cb340a026f1f5eb))
-
-# [1.10.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.5...v1.10.0) (2021-04-01)
+# [1.12.0](https://github.com/kolplattformen/skolplattformen/compare/v1.11.1...v1.12.0) (2021-04-05)
 
 
 ### Features
 
-* 🎸 release 1.6.0 för Android ([241c984](https://github.com/kolplattformen/skolplattformen-app/commit/241c9846a34a025ec480488162a2154184d60a4e))
+* 🎸 Upgrade embedded-api to 3.0.2 ([654471f](https://github.com/kolplattformen/skolplattformen/commit/654471f8030f413e56d9ecdb7c21f730bdef4aff))
 
-## [1.9.5](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.4...v1.9.5) (2021-04-01)
-
-
-### Bug Fixes
-
-* 🐛 Korrekt registrering av CookieJar för Android ([74de762](https://github.com/kolplattformen/skolplattformen-app/commit/74de762f9aa223fc1c7507adf0cfb003994890fd))
-
-## [1.9.4](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.3...v1.9.4) (2021-04-01)
+## [1.11.1](https://github.com/kolplattformen/skolplattformen/compare/v1.11.0...v1.11.1) (2021-04-03)
 
 
 ### Bug Fixes
 
-* förbättra tillgänglighet för länkar i navigering ([#237](https://github.com/kolplattformen/skolplattformen-app/issues/237)) ([9a3b036](https://github.com/kolplattformen/skolplattformen-app/commit/9a3b0360d6f84f5f4070759ec42edb013970d49b))
+* 🐛 Remove warning on markdown component '... unique key ..' ([5ab6ce2](https://github.com/kolplattformen/skolplattformen/commit/5ab6ce2b094aa5becfdb633ec8af071f49fa50ed))
 
-## [1.9.3](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.2...v1.9.3) (2021-03-31)
-
-
-### Bug Fixes
-
-* ta bort anteckningar från kalenderevent ([#231](https://github.com/kolplattformen/skolplattformen-app/issues/231)) ([cf85a52](https://github.com/kolplattformen/skolplattformen-app/commit/cf85a52c50e2a4bfd8062c2000c8f945a5b96799))
-
-## [1.9.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.1...v1.9.2) (2021-03-31)
-
-
-### Bug Fixes
-
-* korrekt registrering av cookie jar ([b24e090](https://github.com/kolplattformen/skolplattformen-app/commit/b24e09047115c043e022a984eae4522ccec24693))
-
-## [1.9.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.9.0...v1.9.1) (2021-03-31)
-
-
-### Bug Fixes
-
-* 🐛 Refactoring and simpler registering of custom cookie jar ([e783504](https://github.com/kolplattformen/skolplattformen-app/commit/e78350414a5206b094fdb2bb8080efba056687a0))
-
-# [1.9.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.8.0...v1.9.0) (2021-03-30)
+# [1.11.0](https://github.com/kolplattformen/skolplattformen/compare/v1.10.4...v1.11.0) (2021-04-03)
 
 
 ### Features
 
-* **site:** add timeline ([#223](https://github.com/kolplattformen/skolplattformen-app/issues/223)) ([1e8a21f](https://github.com/kolplattformen/skolplattformen-app/commit/1e8a21f3fb66102b79361d53cd1d0fae42f8d0de))
+* 🎸 Datum i kalendern ([b1e2d4f](https://github.com/kolplattformen/skolplattformen/commit/b1e2d4f541f44ac0223d12719d1e1caf0f28fd02))
 
-# [1.8.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.7.0...v1.8.0) (2021-03-29)
-
-
-### Features
-
-* 🎸 Di TV ([#221](https://github.com/kolplattformen/skolplattformen-app/issues/221)) ([7dd778a](https://github.com/kolplattformen/skolplattformen-app/commit/7dd778a384e216623ea47c6c5b5027d3018b9b7d))
-
-# [1.7.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.6.0...v1.7.0) (2021-03-29)
-
-
-### Features
-
-* 🎸 Artikel i DI Digital ([#219](https://github.com/kolplattformen/skolplattformen-app/issues/219)) ([ed75f59](https://github.com/kolplattformen/skolplattformen-app/commit/ed75f596795b35f24900607da8d73c747275df08))
-
-# [1.6.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.5.0...v1.6.0) (2021-03-29)
-
-
-### Features
-
-* 🎸 Flyttade upp Media ([#217](https://github.com/kolplattformen/skolplattformen-app/issues/217)) ([ffe71d6](https://github.com/kolplattformen/skolplattformen-app/commit/ffe71d690817313c59cf27e700eb17b3c278aeae))
-* 🎸 Ytterligare media ([c74d650](https://github.com/kolplattformen/skolplattformen-app/commit/c74d6503b636927d8ac83edffb1b589a3bf9908f))
-
-# [1.5.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.4.1...v1.5.0) (2021-03-26)
+## [1.10.4](https://github.com/kolplattformen/skolplattformen/compare/v1.10.3...v1.10.4) (2021-04-02)
 
 
 ### Bug Fixes
 
-* clear AsyncStorage on logout ([c95e00e](https://github.com/kolplattformen/skolplattformen-app/commit/c95e00e0b654ba4666a57cfd0fd12b7dd123d77e))
-* separate navigation stacks ([2dea366](https://github.com/kolplattformen/skolplattformen-app/commit/2dea366427cc37bc47ddc853c7c34d2afa417c42))
+* 🐛 calendar sorting ([c0f5336](https://github.com/kolplattformen/skolplattformen/commit/c0f5336012c7fc7145ba042a1df76054ba1aed75))
+
+## [1.10.3](https://github.com/kolplattformen/skolplattformen/compare/v1.10.2...v1.10.3) (2021-04-02)
+
+
+### Bug Fixes
+
+* 🐛 siffran vid kalenderikonen visade fel antal ([b34a2c2](https://github.com/kolplattformen/skolplattformen/commit/b34a2c20b6b28b3de9cd8bc226813d5b02857144))
+
+## [1.10.2](https://github.com/kolplattformen/skolplattformen/compare/v1.10.1...v1.10.2) (2021-04-02)
+
+
+### Bug Fixes
+
+* 🐛 Fixes issue where settings icon was hidden on Android ([f3d3af1](https://github.com/kolplattformen/skolplattformen/commit/f3d3af1b6e30fa011a6d553b5c9e210aca63cc5c)), closes [#180](https://github.com/kolplattformen/skolplattformen/issues/180)
+
+## [1.10.1](https://github.com/kolplattformen/skolplattformen/compare/v1.10.0...v1.10.1) (2021-04-01)
+
+
+### Bug Fixes
+
+* fel i datumhantering ([#241](https://github.com/kolplattformen/skolplattformen/issues/241)) ([7e1b068](https://github.com/kolplattformen/skolplattformen/commit/7e1b068e8f8fc3a23ad16cc25cb340a026f1f5eb))
+
+# [1.10.0](https://github.com/kolplattformen/skolplattformen/compare/v1.9.5...v1.10.0) (2021-04-01)
 
 
 ### Features
 
-* 🎸 Release 1.5.6 ([68f1f95](https://github.com/kolplattformen/skolplattformen-app/commit/68f1f951ca25d70ff9d2080c1bed1bdd7a461305))
+* 🎸 release 1.6.0 för Android ([241c984](https://github.com/kolplattformen/skolplattformen/commit/241c9846a34a025ec480488162a2154184d60a4e))
 
-## [1.4.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.4.0...v1.4.1) (2021-03-26)
+## [1.9.5](https://github.com/kolplattformen/skolplattformen/compare/v1.9.4...v1.9.5) (2021-04-01)
 
 
 ### Bug Fixes
 
-* avbryt bankid-inloggning ([#209](https://github.com/kolplattformen/skolplattformen-app/issues/209)) ([4732de0](https://github.com/kolplattformen/skolplattformen-app/commit/4732de0819b5984b7a40ea21997cc0a61e481432))
+* 🐛 Korrekt registrering av CookieJar för Android ([74de762](https://github.com/kolplattformen/skolplattformen/commit/74de762f9aa223fc1c7507adf0cfb003994890fd))
 
-# [1.4.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.3.0...v1.4.0) (2021-03-26)
+## [1.9.4](https://github.com/kolplattformen/skolplattformen/compare/v1.9.3...v1.9.4) (2021-04-01)
+
+
+### Bug Fixes
+
+* förbättra tillgänglighet för länkar i navigering ([#237](https://github.com/kolplattformen/skolplattformen/issues/237)) ([9a3b036](https://github.com/kolplattformen/skolplattformen/commit/9a3b0360d6f84f5f4070759ec42edb013970d49b))
+
+## [1.9.3](https://github.com/kolplattformen/skolplattformen/compare/v1.9.2...v1.9.3) (2021-03-31)
+
+
+### Bug Fixes
+
+* ta bort anteckningar från kalenderevent ([#231](https://github.com/kolplattformen/skolplattformen/issues/231)) ([cf85a52](https://github.com/kolplattformen/skolplattformen/commit/cf85a52c50e2a4bfd8062c2000c8f945a5b96799))
+
+## [1.9.2](https://github.com/kolplattformen/skolplattformen/compare/v1.9.1...v1.9.2) (2021-03-31)
+
+
+### Bug Fixes
+
+* korrekt registrering av cookie jar ([b24e090](https://github.com/kolplattformen/skolplattformen/commit/b24e09047115c043e022a984eae4522ccec24693))
+
+## [1.9.1](https://github.com/kolplattformen/skolplattformen/compare/v1.9.0...v1.9.1) (2021-03-31)
+
+
+### Bug Fixes
+
+* 🐛 Refactoring and simpler registering of custom cookie jar ([e783504](https://github.com/kolplattformen/skolplattformen/commit/e78350414a5206b094fdb2bb8080efba056687a0))
+
+# [1.9.0](https://github.com/kolplattformen/skolplattformen/compare/v1.8.0...v1.9.0) (2021-03-30)
 
 
 ### Features
 
-* **ios:** dimma skärmen när man växlar app ([#201](https://github.com/kolplattformen/skolplattformen-app/issues/201)) ([f1b0f4b](https://github.com/kolplattformen/skolplattformen-app/commit/f1b0f4b6f03a1216ef4325592454cb657b11ae02))
+* **site:** add timeline ([#223](https://github.com/kolplattformen/skolplattformen/issues/223)) ([1e8a21f](https://github.com/kolplattformen/skolplattformen/commit/1e8a21f3fb66102b79361d53cd1d0fae42f8d0de))
 
-# [1.3.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.2.1...v1.3.0) (2021-03-25)
-
-
-### Bug Fixes
-
-* do not navigate to children after login ([d6fd614](https://github.com/kolplattformen/skolplattformen-app/commit/d6fd614eabcb94d17e271cf1043f9d58f4165ba6))
-* navigate to child view ([bf05fdb](https://github.com/kolplattformen/skolplattformen-app/commit/bf05fdb4823497da2a56708cd1607ca788f6efbc))
+# [1.8.0](https://github.com/kolplattformen/skolplattformen/compare/v1.7.0...v1.8.0) (2021-03-29)
 
 
 ### Features
 
-* add settings icon ([0b63391](https://github.com/kolplattformen/skolplattformen-app/commit/0b6339154638c4a86840318aca1e92f869d26dab))
-* add settings with logout on children view ([a2b9d30](https://github.com/kolplattformen/skolplattformen-app/commit/a2b9d30282e1bfadd1516469f2b330ada66ff9f5))
-* replace logout screen with children ([c6f4662](https://github.com/kolplattformen/skolplattformen-app/commit/c6f46628750ee208b404c44907ba1e4709bda3b7))
+* 🎸 Di TV ([#221](https://github.com/kolplattformen/skolplattformen/issues/221)) ([7dd778a](https://github.com/kolplattformen/skolplattformen/commit/7dd778a384e216623ea47c6c5b5027d3018b9b7d))
 
-## [1.2.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.2.0...v1.2.1) (2021-03-25)
-
-
-### Bug Fixes
-
-* göm bilder i nyhetslistan för mindre enheter ([#205](https://github.com/kolplattformen/skolplattformen-app/issues/205)) ([480abc4](https://github.com/kolplattformen/skolplattformen-app/commit/480abc4d92c6c6372dbad40e92d26f3b696444f3))
-
-# [1.2.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.1.3...v1.2.0) (2021-03-25)
-
-
-### Bug Fixes
-
-* 🐛 Fixar senaste blocken ([c150216](https://github.com/kolplattformen/skolplattformen-app/commit/c150216e13be5d4166dd65d4edcdda5ee512bc44))
-* 🐛 Login funkar i iOS ([1c3d6f5](https://github.com/kolplattformen/skolplattformen-app/commit/1c3d6f5a5a33d81420b3170083756313341dd1e4))
-* 🐛 Repaired login ([4f6ab3b](https://github.com/kolplattformen/skolplattformen-app/commit/4f6ab3bec7180e9c6771e165a273f1deb37af35b))
-* använd korrekt tusen-separator för miljarden ([#184](https://github.com/kolplattformen/skolplattformen-app/issues/184)) ([8e21ad3](https://github.com/kolplattformen/skolplattformen-app/commit/8e21ad37e65531eb74088b4e210ffd4b9e668b0c))
-* gör båda store-knapparna lika stora ([#185](https://github.com/kolplattformen/skolplattformen-app/issues/185)) ([a35ef5e](https://github.com/kolplattformen/skolplattformen-app/commit/a35ef5edee283dee6312fbd8ce5fe0b0475ca14f))
+# [1.7.0](https://github.com/kolplattformen/skolplattformen/compare/v1.6.0...v1.7.0) (2021-03-29)
 
 
 ### Features
 
-* 🎸 relase 1.4.2 ([8bea63f](https://github.com/kolplattformen/skolplattformen-app/commit/8bea63f75ce40215cd595e87b7d874e94a6cf821))
-* 🎸 release 1.5.3 ([2ce7f01](https://github.com/kolplattformen/skolplattformen-app/commit/2ce7f01c8d552ac6ecc86110e20aeaf2b15a7066))
+* 🎸 Artikel i DI Digital ([#219](https://github.com/kolplattformen/skolplattformen/issues/219)) ([ed75f59](https://github.com/kolplattformen/skolplattformen/commit/ed75f596795b35f24900607da8d73c747275df08))
 
-## [1.1.3](https://github.com/kolplattformen/skolplattformen-app/compare/v1.1.2...v1.1.3) (2021-03-10)
-
-
-### Bug Fixes
-
-* använd korrekt komponent för github-länk ([#183](https://github.com/kolplattformen/skolplattformen-app/issues/183)) ([d9428c9](https://github.com/kolplattformen/skolplattformen-app/commit/d9428c98c8110fcf028dca3598ca6707d7e03643))
-
-## [1.1.2](https://github.com/kolplattformen/skolplattformen-app/compare/v1.1.1...v1.1.2) (2021-02-27)
-
-
-### Bug Fixes
-
-* 🐛 Dekativera klasslistan ([eef1193](https://github.com/kolplattformen/skolplattformen-app/commit/eef1193b598b55c20e895c6ab849e828bc42a252)), closes [#161](https://github.com/kolplattformen/skolplattformen-app/issues/161) [#159](https://github.com/kolplattformen/skolplattformen-app/issues/159)
-
-## [1.1.1](https://github.com/kolplattformen/skolplattformen-app/compare/v1.1.0...v1.1.1) (2021-02-26)
-
-
-### Bug Fixes
-
-* 🐛 Ikoner för initialt iPad stöd ([6ee68bf](https://github.com/kolplattformen/skolplattformen-app/commit/6ee68bf19f0d6849a872bceff1e5b46217f35f4c)), closes [#166](https://github.com/kolplattformen/skolplattformen-app/issues/166)
-
-# [1.1.0](https://github.com/kolplattformen/skolplattformen-app/compare/v1.0.0...v1.1.0) (2021-02-23)
+# [1.6.0](https://github.com/kolplattformen/skolplattformen/compare/v1.5.0...v1.6.0) (2021-03-29)
 
 
 ### Features
 
-* 🎸 Valbar inloggningsmetod ([#172](https://github.com/kolplattformen/skolplattformen-app/issues/172)) ([624c705](https://github.com/kolplattformen/skolplattformen-app/commit/624c705d4bf86005bba82b41f69afce7106101da))
+* 🎸 Flyttade upp Media ([#217](https://github.com/kolplattformen/skolplattformen/issues/217)) ([ffe71d6](https://github.com/kolplattformen/skolplattformen/commit/ffe71d690817313c59cf27e700eb17b3c278aeae))
+* 🎸 Ytterligare media ([c74d650](https://github.com/kolplattformen/skolplattformen/commit/c74d6503b636927d8ac83edffb1b589a3bf9908f))
+
+# [1.5.0](https://github.com/kolplattformen/skolplattformen/compare/v1.4.1...v1.5.0) (2021-03-26)
+
+
+### Bug Fixes
+
+* clear AsyncStorage on logout ([c95e00e](https://github.com/kolplattformen/skolplattformen/commit/c95e00e0b654ba4666a57cfd0fd12b7dd123d77e))
+* separate navigation stacks ([2dea366](https://github.com/kolplattformen/skolplattformen/commit/2dea366427cc37bc47ddc853c7c34d2afa417c42))
+
+
+### Features
+
+* 🎸 Release 1.5.6 ([68f1f95](https://github.com/kolplattformen/skolplattformen/commit/68f1f951ca25d70ff9d2080c1bed1bdd7a461305))
+
+## [1.4.1](https://github.com/kolplattformen/skolplattformen/compare/v1.4.0...v1.4.1) (2021-03-26)
+
+
+### Bug Fixes
+
+* avbryt bankid-inloggning ([#209](https://github.com/kolplattformen/skolplattformen/issues/209)) ([4732de0](https://github.com/kolplattformen/skolplattformen/commit/4732de0819b5984b7a40ea21997cc0a61e481432))
+
+# [1.4.0](https://github.com/kolplattformen/skolplattformen/compare/v1.3.0...v1.4.0) (2021-03-26)
+
+
+### Features
+
+* **ios:** dimma skärmen när man växlar app ([#201](https://github.com/kolplattformen/skolplattformen/issues/201)) ([f1b0f4b](https://github.com/kolplattformen/skolplattformen/commit/f1b0f4b6f03a1216ef4325592454cb657b11ae02))
+
+# [1.3.0](https://github.com/kolplattformen/skolplattformen/compare/v1.2.1...v1.3.0) (2021-03-25)
+
+
+### Bug Fixes
+
+* do not navigate to children after login ([d6fd614](https://github.com/kolplattformen/skolplattformen/commit/d6fd614eabcb94d17e271cf1043f9d58f4165ba6))
+* navigate to child view ([bf05fdb](https://github.com/kolplattformen/skolplattformen/commit/bf05fdb4823497da2a56708cd1607ca788f6efbc))
+
+
+### Features
+
+* add settings icon ([0b63391](https://github.com/kolplattformen/skolplattformen/commit/0b6339154638c4a86840318aca1e92f869d26dab))
+* add settings with logout on children view ([a2b9d30](https://github.com/kolplattformen/skolplattformen/commit/a2b9d30282e1bfadd1516469f2b330ada66ff9f5))
+* replace logout screen with children ([c6f4662](https://github.com/kolplattformen/skolplattformen/commit/c6f46628750ee208b404c44907ba1e4709bda3b7))
+
+## [1.2.1](https://github.com/kolplattformen/skolplattformen/compare/v1.2.0...v1.2.1) (2021-03-25)
+
+
+### Bug Fixes
+
+* göm bilder i nyhetslistan för mindre enheter ([#205](https://github.com/kolplattformen/skolplattformen/issues/205)) ([480abc4](https://github.com/kolplattformen/skolplattformen/commit/480abc4d92c6c6372dbad40e92d26f3b696444f3))
+
+# [1.2.0](https://github.com/kolplattformen/skolplattformen/compare/v1.1.3...v1.2.0) (2021-03-25)
+
+
+### Bug Fixes
+
+* 🐛 Fixar senaste blocken ([c150216](https://github.com/kolplattformen/skolplattformen/commit/c150216e13be5d4166dd65d4edcdda5ee512bc44))
+* 🐛 Login funkar i iOS ([1c3d6f5](https://github.com/kolplattformen/skolplattformen/commit/1c3d6f5a5a33d81420b3170083756313341dd1e4))
+* 🐛 Repaired login ([4f6ab3b](https://github.com/kolplattformen/skolplattformen/commit/4f6ab3bec7180e9c6771e165a273f1deb37af35b))
+* använd korrekt tusen-separator för miljarden ([#184](https://github.com/kolplattformen/skolplattformen/issues/184)) ([8e21ad3](https://github.com/kolplattformen/skolplattformen/commit/8e21ad37e65531eb74088b4e210ffd4b9e668b0c))
+* gör båda store-knapparna lika stora ([#185](https://github.com/kolplattformen/skolplattformen/issues/185)) ([a35ef5e](https://github.com/kolplattformen/skolplattformen/commit/a35ef5edee283dee6312fbd8ce5fe0b0475ca14f))
+
+
+### Features
+
+* 🎸 relase 1.4.2 ([8bea63f](https://github.com/kolplattformen/skolplattformen/commit/8bea63f75ce40215cd595e87b7d874e94a6cf821))
+* 🎸 release 1.5.3 ([2ce7f01](https://github.com/kolplattformen/skolplattformen/commit/2ce7f01c8d552ac6ecc86110e20aeaf2b15a7066))
+
+## [1.1.3](https://github.com/kolplattformen/skolplattformen/compare/v1.1.2...v1.1.3) (2021-03-10)
+
+
+### Bug Fixes
+
+* använd korrekt komponent för github-länk ([#183](https://github.com/kolplattformen/skolplattformen/issues/183)) ([d9428c9](https://github.com/kolplattformen/skolplattformen/commit/d9428c98c8110fcf028dca3598ca6707d7e03643))
+
+## [1.1.2](https://github.com/kolplattformen/skolplattformen/compare/v1.1.1...v1.1.2) (2021-02-27)
+
+
+### Bug Fixes
+
+* 🐛 Dekativera klasslistan ([eef1193](https://github.com/kolplattformen/skolplattformen/commit/eef1193b598b55c20e895c6ab849e828bc42a252)), closes [#161](https://github.com/kolplattformen/skolplattformen/issues/161) [#159](https://github.com/kolplattformen/skolplattformen/issues/159)
+
+## [1.1.1](https://github.com/kolplattformen/skolplattformen/compare/v1.1.0...v1.1.1) (2021-02-26)
+
+
+### Bug Fixes
+
+* 🐛 Ikoner för initialt iPad stöd ([6ee68bf](https://github.com/kolplattformen/skolplattformen/commit/6ee68bf19f0d6849a872bceff1e5b46217f35f4c)), closes [#166](https://github.com/kolplattformen/skolplattformen/issues/166)
+
+# [1.1.0](https://github.com/kolplattformen/skolplattformen/compare/v1.0.0...v1.1.0) (2021-02-23)
+
+
+### Features
+
+* 🎸 Valbar inloggningsmetod ([#172](https://github.com/kolplattformen/skolplattformen/issues/172)) ([624c705](https://github.com/kolplattformen/skolplattformen/commit/624c705d4bf86005bba82b41f69afce7106101da))
 
 # 1.4.0 (2021-02-21)
 
 
 ### Bug Fixes
 
-* 🐛 add missing android release keystore ([75088a2](https://github.com/kolplattformen/skolplattformen-app/commit/75088a284af7c0c4a934bcce10e310ae279cef1e))
-* 🐛 fix state handling on login screen ([a40f596](https://github.com/kolplattformen/skolplattformen-app/commit/a40f596aedb057d9118bdf82edb8faaace5a7ded)), closes [#82](https://github.com/kolplattformen/skolplattformen-app/issues/82)
-* 🐛 Fixed links when navigating other url:s ([53a9425](https://github.com/kolplattformen/skolplattformen-app/commit/53a94251a82db6d58a47af9ab156b1bd1737aea1))
-* 🐛 Fixed merge induced bug ([758738d](https://github.com/kolplattformen/skolplattformen-app/commit/758738dfd495fe2cc4a067e6ccf82e7540d24ca5))
-* 🐛 Fixed so calendar doesn't bork if items don't load ([9b92941](https://github.com/kolplattformen/skolplattformen-app/commit/9b92941adbf39577325a6d6aa3ca157dc679affe))
-* 🐛 handle close of ModalWebView for Android ([f250bcf](https://github.com/kolplattformen/skolplattformen-app/commit/f250bcf803fb4afb8274bbfd9997ce89ac62635f))
-* 🐛 Imported all code onto fresh RN install ([0f15f83](https://github.com/kolplattformen/skolplattformen-app/commit/0f15f83adb0142d9dcce5d3cb80f2e908be49e49))
-* 🐛 Imported all code onto fresh RN install ([#40](https://github.com/kolplattformen/skolplattformen-app/issues/40)) ([f195e37](https://github.com/kolplattformen/skolplattformen-app/commit/f195e37f9985c11b3059daac9bb9b104e4949ad2))
-* 🐛 Länk till issues ([f3f3051](https://github.com/kolplattformen/skolplattformen-app/commit/f3f30513321a6880c44ec168a0ae6d25045ba724))
-* 🐛 Nyheter uppdateras ([eff2ada](https://github.com/kolplattformen/skolplattformen-app/commit/eff2ada06cd139baca2ab2fc586ee39bd497ff72))
-* 🐛 Nyheter uppdateras ([#114](https://github.com/kolplattformen/skolplattformen-app/issues/114)) ([bc56c73](https://github.com/kolplattformen/skolplattformen-app/commit/bc56c735dfd38291a4d1bb7aabebc69e1e04d73b))
-* 🐛 Pnr skickas efter omstart ([0aa68e8](https://github.com/kolplattformen/skolplattformen-app/commit/0aa68e8d91a36ed43aa469bd527591cfbaaf78ac))
-* 🐛 properly load the SSN from the cache ([1051062](https://github.com/kolplattformen/skolplattformen-app/commit/10510620bab850fab3f9af78727ddbc9ca649ffb)), closes [#82](https://github.com/kolplattformen/skolplattformen-app/issues/82)
-* 🐛 remove applicationSuffix for Android debug variant ([52370d9](https://github.com/kolplattformen/skolplattformen-app/commit/52370d9fc5780485b5c80c55c402c9dc1072aa88)), closes [#130](https://github.com/kolplattformen/skolplattformen-app/issues/130)
-* 🐛 Removed lerna workspaces ([823818b](https://github.com/kolplattformen/skolplattformen-app/commit/823818bc92916b6be4b23de17b8040fc0109ce20))
-* 🐛 Rensade länkar ([f4b9538](https://github.com/kolplattformen/skolplattformen-app/commit/f4b95380271421335b18677c93f09e5eb22c5c9b))
-* 🐛 Spelling ([343a98e](https://github.com/kolplattformen/skolplattformen-app/commit/343a98e9db86cec3f8385cd014aa765e88bcbb40))
-* 🐛 Time to read testimonials ([4518ae7](https://github.com/kolplattformen/skolplattformen-app/commit/4518ae7357f4091e5dd75c3e342fa81b5e681511))
-* 🐛 Tog bort omladdning ([723a9df](https://github.com/kolplattformen/skolplattformen-app/commit/723a9dfae0a5e34ffd3ecbefe6eeca5663a5c258))
-* 🐛 Updated api dependencies ([#71](https://github.com/kolplattformen/skolplattformen-app/issues/71)) ([82cbb09](https://github.com/kolplattformen/skolplattformen-app/commit/82cbb094276b3c1b8511d17f10b522faa4b37185))
-* 🐛 Validerar cacheat pnr vid start ([06ff0c7](https://github.com/kolplattformen/skolplattformen-app/commit/06ff0c71e1f0a28a9e514dcf46cbb21e58b704c6))
-* använd statusfält med mörkt innehåll ([#122](https://github.com/kolplattformen/skolplattformen-app/issues/122)) ([b3f88c5](https://github.com/kolplattformen/skolplattformen-app/commit/b3f88c51b937a30581c436b3bab61ce060891a0c))
-* broken title ([37e5750](https://github.com/kolplattformen/skolplattformen-app/commit/37e5750075ea0d680a93dbd9b618f0463393bd5e))
-* check validity of social security number ([582f5de](https://github.com/kolplattformen/skolplattformen-app/commit/582f5deddda2085541f9faa738a79878b6ae2625))
-* contact menu closing on false clicks ([c758370](https://github.com/kolplattformen/skolplattformen-app/commit/c758370074b7e10697855460ce23de45eed2bf99))
-* direktlänkning från knapparna i barnlistan ([491f321](https://github.com/kolplattformen/skolplattformen-app/commit/491f3219abb4b8a4d55c5e9786a01cb6d0c0b1b9))
-* display image of woman if user's socialSecurityNumber is female ([027233f](https://github.com/kolplattformen/skolplattformen-app/commit/027233fd3a2cdc05f0ffda0c1572ee2c667574ee))
-* Enable Google Play Button ([4058428](https://github.com/kolplattformen/skolplattformen-app/commit/4058428393b645158c2c4d9d9e7bb6350ccb656f))
-* göm ogiltiga datum i nyheter ([#152](https://github.com/kolplattformen/skolplattformen-app/issues/152)) ([bac38a2](https://github.com/kolplattformen/skolplattformen-app/commit/bac38a2dec0ddb98a1e4c2023875267fce995377))
-* handle dates and clicks on calendar items ([#64](https://github.com/kolplattformen/skolplattformen-app/issues/64)) ([df63a6b](https://github.com/kolplattformen/skolplattformen-app/commit/df63a6bbdfb1a23269fa741e91ceb995bf8633d8))
-* handle line breaks in tab navigation ([#58](https://github.com/kolplattformen/skolplattformen-app/issues/58)) ([2f6c07a](https://github.com/kolplattformen/skolplattformen-app/commit/2f6c07ac9ce8381d1f8c855896bb619aedda69f2))
-* handle missing social security number ([c596b6c](https://github.com/kolplattformen/skolplattformen-app/commit/c596b6cbb783da665ef896e6e88340479f0ce30d))
-* hantera bilder med absolut url i markdown ([#156](https://github.com/kolplattformen/skolplattformen-app/issues/156)) ([e211439](https://github.com/kolplattformen/skolplattformen-app/commit/e211439336d3038ce6aef86b63a00334296d22cf))
-* hantera lång namn i barnlistan ([aef694c](https://github.com/kolplattformen/skolplattformen-app/commit/aef694cc5730cb3b0c0d906103c30c0014ba1390))
-* hantera ui för saknade datum i aviseringar ([#124](https://github.com/kolplattformen/skolplattformen-app/issues/124)) ([82c2379](https://github.com/kolplattformen/skolplattformen-app/commit/82c23797df1becab86e0efad77163fa7795f0789))
-* hide contact option if not available ([273f059](https://github.com/kolplattformen/skolplattformen-app/commit/273f0597610d766d3a22e96653604cd3ae5cd3b0))
-* ikon och rubrik på Android appen ([8218965](https://github.com/kolplattformen/skolplattformen-app/commit/8218965b0a1f0f701121258d98f713b580a4db25))
-* looked broken when no new event ([#157](https://github.com/kolplattformen/skolplattformen-app/issues/157)) ([a191b45](https://github.com/kolplattformen/skolplattformen-app/commit/a191b450c0f16cfe34f67b7fc0feafb585d1c8ce))
-* scroll i barnlistan och flytta frånvaroknapp ([#167](https://github.com/kolplattformen/skolplattformen-app/issues/167)) ([5a34b7a](https://github.com/kolplattformen/skolplattformen-app/commit/5a34b7a1b4ee22f2596ac1f143c9c5ee6946b94a))
-* **android:** uppdatera färg på statusbar ([#150](https://github.com/kolplattformen/skolplattformen-app/issues/150)) ([b4860e0](https://github.com/kolplattformen/skolplattformen-app/commit/b4860e0f6d4a48fb76ef9f4a659d2dd2d82fdcc6))
-* login screen issues ([#69](https://github.com/kolplattformen/skolplattformen-app/issues/69)) ([ec6a4e0](https://github.com/kolplattformen/skolplattformen-app/commit/ec6a4e088b200443b9dfc1321a8c500bc8bb99ce))
-* removed texts saying the app isnt released and added section for how to report bugs ([#112](https://github.com/kolplattformen/skolplattformen-app/issues/112)) ([61b5189](https://github.com/kolplattformen/skolplattformen-app/commit/61b5189bc5806f640fefc9e5124cdc98a8ffa81d))
-* scroll overflow on child screens ([#65](https://github.com/kolplattformen/skolplattformen-app/issues/65)) ([a05e3c4](https://github.com/kolplattformen/skolplattformen-app/commit/a05e3c4e4a82c55b0fabe34cc36e8d2886a1c232))
-* uppdatera testimonial med rätt text ([#137](https://github.com/kolplattformen/skolplattformen-app/issues/137)) ([be228d1](https://github.com/kolplattformen/skolplattformen-app/commit/be228d123fa4142118ba96c18ff24ad9bac7add8))
-* use nextjs link for integrity policy ([fce2c26](https://github.com/kolplattformen/skolplattformen-app/commit/fce2c260cbeee1208613697b4f106adf8f50b02e))
+* 🐛 add missing android release keystore ([75088a2](https://github.com/kolplattformen/skolplattformen/commit/75088a284af7c0c4a934bcce10e310ae279cef1e))
+* 🐛 fix state handling on login screen ([a40f596](https://github.com/kolplattformen/skolplattformen/commit/a40f596aedb057d9118bdf82edb8faaace5a7ded)), closes [#82](https://github.com/kolplattformen/skolplattformen/issues/82)
+* 🐛 Fixed links when navigating other url:s ([53a9425](https://github.com/kolplattformen/skolplattformen/commit/53a94251a82db6d58a47af9ab156b1bd1737aea1))
+* 🐛 Fixed merge induced bug ([758738d](https://github.com/kolplattformen/skolplattformen/commit/758738dfd495fe2cc4a067e6ccf82e7540d24ca5))
+* 🐛 Fixed so calendar doesn't bork if items don't load ([9b92941](https://github.com/kolplattformen/skolplattformen/commit/9b92941adbf39577325a6d6aa3ca157dc679affe))
+* 🐛 handle close of ModalWebView for Android ([f250bcf](https://github.com/kolplattformen/skolplattformen/commit/f250bcf803fb4afb8274bbfd9997ce89ac62635f))
+* 🐛 Imported all code onto fresh RN install ([0f15f83](https://github.com/kolplattformen/skolplattformen/commit/0f15f83adb0142d9dcce5d3cb80f2e908be49e49))
+* 🐛 Imported all code onto fresh RN install ([#40](https://github.com/kolplattformen/skolplattformen/issues/40)) ([f195e37](https://github.com/kolplattformen/skolplattformen/commit/f195e37f9985c11b3059daac9bb9b104e4949ad2))
+* 🐛 Länk till issues ([f3f3051](https://github.com/kolplattformen/skolplattformen/commit/f3f30513321a6880c44ec168a0ae6d25045ba724))
+* 🐛 Nyheter uppdateras ([eff2ada](https://github.com/kolplattformen/skolplattformen/commit/eff2ada06cd139baca2ab2fc586ee39bd497ff72))
+* 🐛 Nyheter uppdateras ([#114](https://github.com/kolplattformen/skolplattformen/issues/114)) ([bc56c73](https://github.com/kolplattformen/skolplattformen/commit/bc56c735dfd38291a4d1bb7aabebc69e1e04d73b))
+* 🐛 Pnr skickas efter omstart ([0aa68e8](https://github.com/kolplattformen/skolplattformen/commit/0aa68e8d91a36ed43aa469bd527591cfbaaf78ac))
+* 🐛 properly load the SSN from the cache ([1051062](https://github.com/kolplattformen/skolplattformen/commit/10510620bab850fab3f9af78727ddbc9ca649ffb)), closes [#82](https://github.com/kolplattformen/skolplattformen/issues/82)
+* 🐛 remove applicationSuffix for Android debug variant ([52370d9](https://github.com/kolplattformen/skolplattformen/commit/52370d9fc5780485b5c80c55c402c9dc1072aa88)), closes [#130](https://github.com/kolplattformen/skolplattformen/issues/130)
+* 🐛 Removed lerna workspaces ([823818b](https://github.com/kolplattformen/skolplattformen/commit/823818bc92916b6be4b23de17b8040fc0109ce20))
+* 🐛 Rensade länkar ([f4b9538](https://github.com/kolplattformen/skolplattformen/commit/f4b95380271421335b18677c93f09e5eb22c5c9b))
+* 🐛 Spelling ([343a98e](https://github.com/kolplattformen/skolplattformen/commit/343a98e9db86cec3f8385cd014aa765e88bcbb40))
+* 🐛 Time to read testimonials ([4518ae7](https://github.com/kolplattformen/skolplattformen/commit/4518ae7357f4091e5dd75c3e342fa81b5e681511))
+* 🐛 Tog bort omladdning ([723a9df](https://github.com/kolplattformen/skolplattformen/commit/723a9dfae0a5e34ffd3ecbefe6eeca5663a5c258))
+* 🐛 Updated api dependencies ([#71](https://github.com/kolplattformen/skolplattformen/issues/71)) ([82cbb09](https://github.com/kolplattformen/skolplattformen/commit/82cbb094276b3c1b8511d17f10b522faa4b37185))
+* 🐛 Validerar cacheat pnr vid start ([06ff0c7](https://github.com/kolplattformen/skolplattformen/commit/06ff0c71e1f0a28a9e514dcf46cbb21e58b704c6))
+* använd statusfält med mörkt innehåll ([#122](https://github.com/kolplattformen/skolplattformen/issues/122)) ([b3f88c5](https://github.com/kolplattformen/skolplattformen/commit/b3f88c51b937a30581c436b3bab61ce060891a0c))
+* broken title ([37e5750](https://github.com/kolplattformen/skolplattformen/commit/37e5750075ea0d680a93dbd9b618f0463393bd5e))
+* check validity of social security number ([582f5de](https://github.com/kolplattformen/skolplattformen/commit/582f5deddda2085541f9faa738a79878b6ae2625))
+* contact menu closing on false clicks ([c758370](https://github.com/kolplattformen/skolplattformen/commit/c758370074b7e10697855460ce23de45eed2bf99))
+* direktlänkning från knapparna i barnlistan ([491f321](https://github.com/kolplattformen/skolplattformen/commit/491f3219abb4b8a4d55c5e9786a01cb6d0c0b1b9))
+* display image of woman if user's socialSecurityNumber is female ([027233f](https://github.com/kolplattformen/skolplattformen/commit/027233fd3a2cdc05f0ffda0c1572ee2c667574ee))
+* Enable Google Play Button ([4058428](https://github.com/kolplattformen/skolplattformen/commit/4058428393b645158c2c4d9d9e7bb6350ccb656f))
+* göm ogiltiga datum i nyheter ([#152](https://github.com/kolplattformen/skolplattformen/issues/152)) ([bac38a2](https://github.com/kolplattformen/skolplattformen/commit/bac38a2dec0ddb98a1e4c2023875267fce995377))
+* handle dates and clicks on calendar items ([#64](https://github.com/kolplattformen/skolplattformen/issues/64)) ([df63a6b](https://github.com/kolplattformen/skolplattformen/commit/df63a6bbdfb1a23269fa741e91ceb995bf8633d8))
+* handle line breaks in tab navigation ([#58](https://github.com/kolplattformen/skolplattformen/issues/58)) ([2f6c07a](https://github.com/kolplattformen/skolplattformen/commit/2f6c07ac9ce8381d1f8c855896bb619aedda69f2))
+* handle missing social security number ([c596b6c](https://github.com/kolplattformen/skolplattformen/commit/c596b6cbb783da665ef896e6e88340479f0ce30d))
+* hantera bilder med absolut url i markdown ([#156](https://github.com/kolplattformen/skolplattformen/issues/156)) ([e211439](https://github.com/kolplattformen/skolplattformen/commit/e211439336d3038ce6aef86b63a00334296d22cf))
+* hantera lång namn i barnlistan ([aef694c](https://github.com/kolplattformen/skolplattformen/commit/aef694cc5730cb3b0c0d906103c30c0014ba1390))
+* hantera ui för saknade datum i aviseringar ([#124](https://github.com/kolplattformen/skolplattformen/issues/124)) ([82c2379](https://github.com/kolplattformen/skolplattformen/commit/82c23797df1becab86e0efad77163fa7795f0789))
+* hide contact option if not available ([273f059](https://github.com/kolplattformen/skolplattformen/commit/273f0597610d766d3a22e96653604cd3ae5cd3b0))
+* ikon och rubrik på Android appen ([8218965](https://github.com/kolplattformen/skolplattformen/commit/8218965b0a1f0f701121258d98f713b580a4db25))
+* looked broken when no new event ([#157](https://github.com/kolplattformen/skolplattformen/issues/157)) ([a191b45](https://github.com/kolplattformen/skolplattformen/commit/a191b450c0f16cfe34f67b7fc0feafb585d1c8ce))
+* scroll i barnlistan och flytta frånvaroknapp ([#167](https://github.com/kolplattformen/skolplattformen/issues/167)) ([5a34b7a](https://github.com/kolplattformen/skolplattformen/commit/5a34b7a1b4ee22f2596ac1f143c9c5ee6946b94a))
+* **android:** uppdatera färg på statusbar ([#150](https://github.com/kolplattformen/skolplattformen/issues/150)) ([b4860e0](https://github.com/kolplattformen/skolplattformen/commit/b4860e0f6d4a48fb76ef9f4a659d2dd2d82fdcc6))
+* login screen issues ([#69](https://github.com/kolplattformen/skolplattformen/issues/69)) ([ec6a4e0](https://github.com/kolplattformen/skolplattformen/commit/ec6a4e088b200443b9dfc1321a8c500bc8bb99ce))
+* removed texts saying the app isnt released and added section for how to report bugs ([#112](https://github.com/kolplattformen/skolplattformen/issues/112)) ([61b5189](https://github.com/kolplattformen/skolplattformen/commit/61b5189bc5806f640fefc9e5124cdc98a8ffa81d))
+* scroll overflow on child screens ([#65](https://github.com/kolplattformen/skolplattformen/issues/65)) ([a05e3c4](https://github.com/kolplattformen/skolplattformen/commit/a05e3c4e4a82c55b0fabe34cc36e8d2886a1c232))
+* uppdatera testimonial med rätt text ([#137](https://github.com/kolplattformen/skolplattformen/issues/137)) ([be228d1](https://github.com/kolplattformen/skolplattformen/commit/be228d123fa4142118ba96c18ff24ad9bac7add8))
+* use nextjs link for integrity policy ([fce2c26](https://github.com/kolplattformen/skolplattformen/commit/fce2c260cbeee1208613697b4f106adf8f50b02e))
 
 
 ### Features
 
-* 🎸 Added privacy policy and changed price to 12 ([34b1a3c](https://github.com/kolplattformen/skolplattformen-app/commit/34b1a3cd78207b5fe1f022ceae4431c39e866aca))
-* 🎸 Dra och ladda om ([5fb5587](https://github.com/kolplattformen/skolplattformen-app/commit/5fb55875b8c30191c1847461575c1b1ff8c57345))
-* 🎸 Encrypted cookie ([3419eda](https://github.com/kolplattformen/skolplattformen-app/commit/3419edab918b03396a0e839981d37c47fa2d28a5))
-* 🎸 Ingress under bild ([b3f1d57](https://github.com/kolplattformen/skolplattformen-app/commit/b3f1d5749066925c0b8c68deb0c3dae92f8addb8))
-* 🎸 Ladda alla nyheter ([8b913c6](https://github.com/kolplattformen/skolplattformen-app/commit/8b913c65933e16d7d1210f67beef22686be2cc5b))
-* 🎸 Links i markdown ([#86](https://github.com/kolplattformen/skolplattformen-app/issues/86)) ([7b165af](https://github.com/kolplattformen/skolplattformen-app/commit/7b165af78ff2cce859c708d43d2ee8392102735a)), closes [#73](https://github.com/kolplattformen/skolplattformen-app/issues/73)
-* 🎸 Login works with 201212121212 ([f57212e](https://github.com/kolplattformen/skolplattformen-app/commit/f57212e40c128c0ce9183b0750a736a9533625a3))
-* 🎸 Notifications viewable ([1a80f89](https://github.com/kolplattformen/skolplattformen-app/commit/1a80f89c0a5e085a5c1b9e780429f9e11beb5091))
-* 🎸 Notifications viewable ([e6335ec](https://github.com/kolplattformen/skolplattformen-app/commit/e6335ecb037c4c1c3ca91e32ca51bec2d75bb46d))
-* 🎸 Ombyggd nyhetsbrevshantering ([#111](https://github.com/kolplattformen/skolplattformen-app/issues/111)) ([2b8133d](https://github.com/kolplattformen/skolplattformen-app/commit/2b8133daa5197c4085efaf58eb3fe45b6caeb20f))
-* 🎸 På sajten kan vi i alla fall köra analytics :smile: ([#79](https://github.com/kolplattformen/skolplattformen-app/issues/79)) ([7973285](https://github.com/kolplattformen/skolplattformen-app/commit/797328569c334510543ff5965a4f7262b43ade16))
-* 🎸 Readable news and updated navigation ([5835268](https://github.com/kolplattformen/skolplattformen-app/commit/5835268efd0f04c6655742d0f17c50e4e2eaae2c))
-* 🎸 Readable news and updated navigation ([79b80a1](https://github.com/kolplattformen/skolplattformen-app/commit/79b80a14eb7033c2dbfa411c0ffd74c6a227a3ba))
-* 🎸 Removed download from head, added buttons to banner ([#42](https://github.com/kolplattformen/skolplattformen-app/issues/42)) ([1e45d28](https://github.com/kolplattformen/skolplattformen-app/commit/1e45d283ab1243e99a45c6e9092dcd7079629d7d))
-* 🎸 Updated API. Now with fake news images ([0367f60](https://github.com/kolplattformen/skolplattformen-app/commit/0367f60eec76a822e9fa0ff66c9381ed41138dba))
-* 🎸 Updated API. Now with fake news images ([5ef9ca1](https://github.com/kolplattformen/skolplattformen-app/commit/5ef9ca1ac61e83c5a7ee71c49cd71b2b6e7d5e48))
-* 🎸 Using new fullImageUrl and cookie features for news img ([3fb3d89](https://github.com/kolplattformen/skolplattformen-app/commit/3fb3d8903b3dc4e74f602c26503219678f2d9a2d))
-* add app store link ([#74](https://github.com/kolplattformen/skolplattformen-app/issues/74)) ([5e6e91d](https://github.com/kolplattformen/skolplattformen-app/commit/5e6e91dc4697aaf597052f06c01a7945dfed1e2e))
-* add email on site ([#70](https://github.com/kolplattformen/skolplattformen-app/issues/70)) ([27229cc](https://github.com/kolplattformen/skolplattformen-app/commit/27229ccb68c451623dbb54c62bc14fd948711fe2))
-* add Open Graph title, image and description ([524a118](https://github.com/kolplattformen/skolplattformen-app/commit/524a11843c8ff430be508daf0976f5a655698dae))
-* add Q&A page ([0b816d9](https://github.com/kolplattformen/skolplattformen-app/commit/0b816d972cf093c661c23d8975dce7fb36755277))
-* added npm lib and implemented login and load children ([c2ab194](https://github.com/kolplattformen/skolplattformen-app/commit/c2ab19407907a86223ece795340f233f1f9f34ee))
-* Datum på nyheter ([#110](https://github.com/kolplattformen/skolplattformen-app/issues/110)) ([cea1080](https://github.com/kolplattformen/skolplattformen-app/commit/cea1080e1e8c11e68b7b6a3a5004e63cff6ff2b9))
-* Flyttade tabbarna längst ner ([#145](https://github.com/kolplattformen/skolplattformen-app/issues/145)) ([6c1ceae](https://github.com/kolplattformen/skolplattformen-app/commit/6c1ceaee3430f0d6ddad15ecdf060d21f0d38aad))
-* frånvaroanmälan ([#144](https://github.com/kolplattformen/skolplattformen-app/issues/144)) ([090a59e](https://github.com/kolplattformen/skolplattformen-app/commit/090a59e41c985999a6ffec94318d9a7ecae2df5c))
-* lägg till empty state för barnlistan ([#126](https://github.com/kolplattformen/skolplattformen-app/issues/126)) ([0cb24fe](https://github.com/kolplattformen/skolplattformen-app/commit/0cb24fe74d1a418fb3a2f20f70a2a692e6ecd4cd))
-* optimise images with next/image  ([#54](https://github.com/kolplattformen/skolplattformen-app/issues/54)) ([fbbf6fe](https://github.com/kolplattformen/skolplattformen-app/commit/fbbf6feaf1229435f941b70d637c2f5a74a443ed)), closes [#29](https://github.com/kolplattformen/skolplattformen-app/issues/29)
-* upgrade to next@10 to be able to use next/image ([082ea67](https://github.com/kolplattformen/skolplattformen-app/commit/082ea6714040f960b79339c0ca08415abb04cdcc))
+* 🎸 Added privacy policy and changed price to 12 ([34b1a3c](https://github.com/kolplattformen/skolplattformen/commit/34b1a3cd78207b5fe1f022ceae4431c39e866aca))
+* 🎸 Dra och ladda om ([5fb5587](https://github.com/kolplattformen/skolplattformen/commit/5fb55875b8c30191c1847461575c1b1ff8c57345))
+* 🎸 Encrypted cookie ([3419eda](https://github.com/kolplattformen/skolplattformen/commit/3419edab918b03396a0e839981d37c47fa2d28a5))
+* 🎸 Ingress under bild ([b3f1d57](https://github.com/kolplattformen/skolplattformen/commit/b3f1d5749066925c0b8c68deb0c3dae92f8addb8))
+* 🎸 Ladda alla nyheter ([8b913c6](https://github.com/kolplattformen/skolplattformen/commit/8b913c65933e16d7d1210f67beef22686be2cc5b))
+* 🎸 Links i markdown ([#86](https://github.com/kolplattformen/skolplattformen/issues/86)) ([7b165af](https://github.com/kolplattformen/skolplattformen/commit/7b165af78ff2cce859c708d43d2ee8392102735a)), closes [#73](https://github.com/kolplattformen/skolplattformen/issues/73)
+* 🎸 Login works with 201212121212 ([f57212e](https://github.com/kolplattformen/skolplattformen/commit/f57212e40c128c0ce9183b0750a736a9533625a3))
+* 🎸 Notifications viewable ([1a80f89](https://github.com/kolplattformen/skolplattformen/commit/1a80f89c0a5e085a5c1b9e780429f9e11beb5091))
+* 🎸 Notifications viewable ([e6335ec](https://github.com/kolplattformen/skolplattformen/commit/e6335ecb037c4c1c3ca91e32ca51bec2d75bb46d))
+* 🎸 Ombyggd nyhetsbrevshantering ([#111](https://github.com/kolplattformen/skolplattformen/issues/111)) ([2b8133d](https://github.com/kolplattformen/skolplattformen/commit/2b8133daa5197c4085efaf58eb3fe45b6caeb20f))
+* 🎸 På sajten kan vi i alla fall köra analytics :smile: ([#79](https://github.com/kolplattformen/skolplattformen/issues/79)) ([7973285](https://github.com/kolplattformen/skolplattformen/commit/797328569c334510543ff5965a4f7262b43ade16))
+* 🎸 Readable news and updated navigation ([5835268](https://github.com/kolplattformen/skolplattformen/commit/5835268efd0f04c6655742d0f17c50e4e2eaae2c))
+* 🎸 Readable news and updated navigation ([79b80a1](https://github.com/kolplattformen/skolplattformen/commit/79b80a14eb7033c2dbfa411c0ffd74c6a227a3ba))
+* 🎸 Removed download from head, added buttons to banner ([#42](https://github.com/kolplattformen/skolplattformen/issues/42)) ([1e45d28](https://github.com/kolplattformen/skolplattformen/commit/1e45d283ab1243e99a45c6e9092dcd7079629d7d))
+* 🎸 Updated API. Now with fake news images ([0367f60](https://github.com/kolplattformen/skolplattformen/commit/0367f60eec76a822e9fa0ff66c9381ed41138dba))
+* 🎸 Updated API. Now with fake news images ([5ef9ca1](https://github.com/kolplattformen/skolplattformen/commit/5ef9ca1ac61e83c5a7ee71c49cd71b2b6e7d5e48))
+* 🎸 Using new fullImageUrl and cookie features for news img ([3fb3d89](https://github.com/kolplattformen/skolplattformen/commit/3fb3d8903b3dc4e74f602c26503219678f2d9a2d))
+* add app store link ([#74](https://github.com/kolplattformen/skolplattformen/issues/74)) ([5e6e91d](https://github.com/kolplattformen/skolplattformen/commit/5e6e91dc4697aaf597052f06c01a7945dfed1e2e))
+* add email on site ([#70](https://github.com/kolplattformen/skolplattformen/issues/70)) ([27229cc](https://github.com/kolplattformen/skolplattformen/commit/27229ccb68c451623dbb54c62bc14fd948711fe2))
+* add Open Graph title, image and description ([524a118](https://github.com/kolplattformen/skolplattformen/commit/524a11843c8ff430be508daf0976f5a655698dae))
+* add Q&A page ([0b816d9](https://github.com/kolplattformen/skolplattformen/commit/0b816d972cf093c661c23d8975dce7fb36755277))
+* added npm lib and implemented login and load children ([c2ab194](https://github.com/kolplattformen/skolplattformen/commit/c2ab19407907a86223ece795340f233f1f9f34ee))
+* Datum på nyheter ([#110](https://github.com/kolplattformen/skolplattformen/issues/110)) ([cea1080](https://github.com/kolplattformen/skolplattformen/commit/cea1080e1e8c11e68b7b6a3a5004e63cff6ff2b9))
+* Flyttade tabbarna längst ner ([#145](https://github.com/kolplattformen/skolplattformen/issues/145)) ([6c1ceae](https://github.com/kolplattformen/skolplattformen/commit/6c1ceaee3430f0d6ddad15ecdf060d21f0d38aad))
+* frånvaroanmälan ([#144](https://github.com/kolplattformen/skolplattformen/issues/144)) ([090a59e](https://github.com/kolplattformen/skolplattformen/commit/090a59e41c985999a6ffec94318d9a7ecae2df5c))
+* lägg till empty state för barnlistan ([#126](https://github.com/kolplattformen/skolplattformen/issues/126)) ([0cb24fe](https://github.com/kolplattformen/skolplattformen/commit/0cb24fe74d1a418fb3a2f20f70a2a692e6ecd4cd))
+* optimise images with next/image  ([#54](https://github.com/kolplattformen/skolplattformen/issues/54)) ([fbbf6fe](https://github.com/kolplattformen/skolplattformen/commit/fbbf6feaf1229435f941b70d637c2f5a74a443ed)), closes [#29](https://github.com/kolplattformen/skolplattformen/issues/29)
+* upgrade to next@10 to be able to use next/image ([082ea67](https://github.com/kolplattformen/skolplattformen/commit/082ea6714040f960b79339c0ca08415abb04cdcc))
 
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Once done, create a _pull request_ where you explain why we should incorporate y
 If you're new to GitHub, there's a number of excellent guides available, such as [this one on forking projects and making pull requests](https://guides.github.com/activities/forking/).
 
 There are many ways to contribute to the project. \
-If you don't know how to program and want help, you can [file an issue](https://github.com/kolplattformen/skolplattformen-app/issues/new) to let us know when something isn't working properly. \
+If you don't know how to program and want help, you can [file an issue](https://github.com/kolplattformen/skolplattformen/issues/new) to let us know when something isn't working properly. \
 We're super duper happy for both issues and pull requests, and we try to answer all of them as soon as humanly possible.
 
 Another way to contribute is by helping translate Öppna skolplattformen [on Hosted Weblate](https://hosted.weblate.org/engage/skolplattformen-app/) into a new language, or to improve existing translations.

--- a/apps/website/components/Privacy.tsx
+++ b/apps/website/components/Privacy.tsx
@@ -87,7 +87,7 @@ const Privacy = () => {
         <p>
           Denna integritetspolicy gäller fr.o.m. 2021-09-13. Ändringar i denna
           policy finns dokumenterade på vår{' '}
-          <Link.External href="https://github.com/kolplattformen/skolplattformen-app/">
+          <Link.External href="https://github.com/kolplattformen/skolplattformen/">
             GitHub
           </Link.External>
           .

--- a/apps/website/components/Status.tsx
+++ b/apps/website/components/Status.tsx
@@ -16,13 +16,13 @@ const Status = () => {
         <ul>
           <li>Skicka en tweet 🥉</li>
           <li>
-            <a href="https://github.com/kolplattformen/skolplattformen-app/issues">
+            <a href="https://github.com/kolplattformen/skolplattformen/issues">
               Lägg en buggrapport här
             </a>{' '}
             🥈
           </li>
           <li>
-            <a href="https://github.com/kolplattformen/skolplattformen-app/pulls">
+            <a href="https://github.com/kolplattformen/skolplattformen/pulls">
               Skicka en PR
             </a>{' '}
             🥇

--- a/libs/api-skolplattformen/lib/parse/news.ts
+++ b/libs/api-skolplattformen/lib/parse/news.ts
@@ -27,7 +27,7 @@ export const newsItem = ({
   body: toNonEmptyMarkdownString(body),
 })
 
-// Fixes https://github.com/kolplattformen/skolplattformen-app/issues/525
+// Fixes https://github.com/kolplattformen/skolplattformen/issues/525
 const toNonEmptyMarkdownString = (str: string): string => {
   const res = toMarkdown(str)
   if (res?.length == 0) return ' '


### PR DESCRIPTION
Cool project 😎 I came across this on Twitter and noticed that a GitHub link on the Q&A page was broken. Looks like the name of this repo was changed late 2021?

This PR changes all references `kolplattformen/skolplattformen-app` -> `kolplattformen/skolplattformen`.